### PR TITLE
hw: add missing test_depend on description pkg.

### DIFF
--- a/franka_hw/package.xml
+++ b/franka_hw/package.xml
@@ -19,6 +19,7 @@
   <depend>joint_limits_interface</depend>
   <depend>roscpp</depend>
 
+  <test_depend>franka_description</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
As per subject.

Looking through the files in `franka_hw`, I believe `franka_description` is only a `test_depend`, so I added it as such to the manifest.
