### PR TITLE
add joint_limits_interface to catkin_packages to build witk catkin build

### DIFF
--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(Franka 0.4.0 REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES franka_hw
-  CATKIN_DEPENDS controller_interface hardware_interface roscpp
+  CATKIN_DEPENDS controller_interface hardware_interface joint_limits_interface roscpp
   DEPENDS Franka
 )
 


### PR DESCRIPTION
Hi,
when building the franka_ros packages with the catkin-tools (aka catkin build) the build fails with

`
In file included from /home/jkur/ros/src/franka_ros/franka_control/src/franka_control_node.cpp:13:0:
/home/jkur/ros/src/franka_ros/franka_hw/include/franka_hw/franka_hw.h:17:10: fatal error: joint_limits_interface/joint_limits_interface.h: Datei oder Verzeichnis nicht gefunden
 #include <joint_limits_interface/joint_limits_interface.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/franka_control_node.dir/src/franka_control_node.cpp.o] Fehler 1
make[1]: *** [CMakeFiles/franka_control_node.dir/all] Fehler 2
make: *** [all] Fehler 2
`

Adding the joint_limits_interface in the CMakeLists.txt fixes this.

