### PR TITLE
Removed panda_moveit_config dependency in franka_ros

### DIFF
--- a/franka_ros/package.xml
+++ b/franka_ros/package.xml
@@ -15,7 +15,6 @@
 
   <exec_depend>franka_control</exec_depend>
   <exec_depend>franka_description</exec_depend>
-  <exec_depend>franka_example_controllers</exec_depend>
   <exec_depend>franka_gripper</exec_depend>
   <exec_depend>franka_hw</exec_depend>
   <exec_depend>franka_msgs</exec_depend>

--- a/franka_ros/package.xml
+++ b/franka_ros/package.xml
@@ -20,7 +20,6 @@
   <exec_depend>franka_hw</exec_depend>
   <exec_depend>franka_msgs</exec_depend>
   <exec_depend>franka_visualization</exec_depend>
-  <exec_depend>panda_moveit_config</exec_depend>
 
   <export>
     <metapackage />


### PR DESCRIPTION
Hello, I have been installing franka_ros with ros noetic on ubuntu 20.04 and I noticed that the ros-noetic-franka-ros is not available on apt. By taking a quick look at jenkins (https://build.ros.org/job/Ndev__franka_ros__ubuntu_focal_amd64/4/console) it looks like the build is failing due to the panda_moveit_config dependency in franka_ros. This because panda_moveit_config is also not available in noetic. From what I understand this dependency is a remnant from when panda_moveit_config was a part of this repository, so it should be possible to safely remove it.