### PR TITLE
Updates state_publisher to robot_state_publisher in the franka_visualization package

### DIFF
--- a/franka_visualization/launch/franka_visualization.launch
+++ b/franka_visualization/launch/franka_visualization.launch
@@ -24,6 +24,6 @@
     <rosparam param="source_list">[robot_joint_state_publisher/joint_states, gripper_joint_state_publisher/joint_states]</rosparam>
   </node>
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node pkg="rviz" type="rviz" output="screen" name="rviz" args="-d $(find franka_visualization)/launch/franka_visualization.rviz"/>
 </launch>


### PR DESCRIPTION
This commit removes the deprecated 'state_publisher' alias and replaces it with the new 'robot_state_publisher'. See
https://github.com/ros/robot_state_publisher/pull/87.