### PR TITLE
Removes depricated --inorder xacro argument

### DIFF
--- a/franka_control/launch/franka_combined_control.launch
+++ b/franka_control/launch/franka_combined_control.launch
@@ -32,7 +32,7 @@
     <rosparam command="load" file="$(arg hw_config_file)" />
     <!-- Add or overwrite manually configured ips -->
     <rosparam subst_value="True">$(arg robot_ips)</rosparam>
-    <param name="robot_description" command="xacro --inorder $(arg robot) $(arg args)" />
+    <param name="robot_description" command="xacro $(arg robot) $(arg args)" />
   </node>
 
   <group ns="$(arg robot_id)">
@@ -43,7 +43,7 @@
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
     <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-      <param name="robot_description" command="xacro --inorder $(arg robot) $(arg args)" />
+      <param name="robot_description" command="xacro $(arg robot) $(arg args)" />
       <rosparam param="source_list"  subst_value="true">$(arg joint_states_source_list)</rosparam>
       <param name="rate" value="30"/>
     </node>

--- a/franka_control/launch/franka_control.launch
+++ b/franka_control/launch/franka_control.launch
@@ -3,7 +3,7 @@
   <arg name="robot_ip" />
   <arg name="load_gripper" default="true" />
 
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
 
   <include file="$(find franka_gripper)/launch/franka_gripper.launch" if="$(arg load_gripper)">
     <arg name="robot_ip" value="$(arg robot_ip)" />

--- a/franka_hw/test/launch/franka_hw_test.test
+++ b/franka_hw/test/launch/franka_hw_test.test
@@ -1,6 +1,6 @@
 <launch>
  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find franka_hw)/test/config/ros_console_settings_for_tests.conf"/>
- <param name="robot_description" command="$(find xacro)/xacro --inorder $(find franka_description)/robots/panda_arm.urdf.xacro" />
+ <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro" />
  <test test-name="franka_hw_test" pkg="franka_hw" type="franka_hw_test" >
    <rosparam command="load" file="$(find franka_control)/config/franka_control_node.yaml" />
    <param name="robot_ip" value="unused_dummy_ip" />

--- a/franka_visualization/launch/franka_visualization.launch
+++ b/franka_visualization/launch/franka_visualization.launch
@@ -5,7 +5,7 @@
   <arg name="robot_ip" />
   <arg name="publish_rate" default="30" />
 
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
 
   <node name="robot_joint_state_publisher" pkg="franka_visualization" type="robot_joint_state_publisher" output="screen">
     <rosparam command="load" file="$(find franka_visualization)/config/robot_settings.yaml" />


### PR DESCRIPTION
This commit removes the --inorder argument from any `xacro` commands. This was done to remove the `--inorder` deprecation warning.