### PR TITLE
Fixes CMP0048 CMake warning

### DIFF
--- a/franka_ros/CMakeLists.txt
+++ b/franka_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.4)
 project(franka_ros)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
This pull request get's rid of the CMP0048 warning that is thrown when the CMake minimum version is too low.