### PR TITLE
Fixes missing example controllers dependency

### DIFF
--- a/franka_example_controllers/package.xml
+++ b/franka_example_controllers/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>franka_description</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>panda_moveit_config</exec_depend>
+  <exec_depend>moveit_commander</exec_depend>
   <exec_depend>rospy</exec_depend>
 
   <export>


### PR DESCRIPTION
As, some scripts use the uses the moveit_commander (e.g. [move_to_start.py](https://github.com/frankaemika/franka_ros/blob/356ec114c488c75edeaf5315633359459d37af31/franka_example_controllers/scripts/move_to_start.py#L4)) it should be added as a ROS dependency.