### PR TITLE
Add desired_joint_states to panda gazebo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.x - UNRELEASED
+
+* Add `joint_state_desired` publisher to `franka_gazebo`
+
 ## 0.8.1 - 2021-09-08
 
 Requires `libfranka` >= 0.8.0

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -90,6 +90,11 @@
       <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
       <param name="rate" value="30"/>
     </node>
+    <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
+      <rosparam param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
+      <param name="rate" value="30"/>
+      <remap from="joint_states" to="joint_states_desired" />
+    </node>
 
     <!-- Start only if cartesian_impedance_example_controller -->
     <node name="interactive_marker"


### PR DESCRIPTION
This commit adds the desired_joint_states topic to the gazebo simulation. Although this topic is not needed it makes the gazebo simulation more in line with the real system.
