### PR TITLE
Improves hand/finger collision geometries

### DIFF
--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -16,39 +16,21 @@
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0.04" rpy="0 ${pi/2} ${pi/2}"/>
-        <geometry>
-          <cylinder radius="${0.04+safety_distance}" length="0.1" />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 -0.05 0.04" rpy="0 0 0"/>
+        <origin xyz="0 0.065 0.027" rpy="0 0 0"/>
         <geometry>
           <sphere radius="${0.04+safety_distance}"  />
         </geometry>
       </collision>
       <collision>
-        <origin xyz="0 0.05 0.04" rpy="0 0 0"/>
+        <origin xyz="0 0 0.027" rpy="0 ${pi/2} ${pi/2}"/>
+        <geometry>
+          <cylinder radius="${0.04+safety_distance}" length="0.135" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 -0.065 0.027" rpy="0 0 0"/>
         <geometry>
           <sphere radius="${0.04+safety_distance}"  />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 0 0.1" rpy="0 ${pi/2} ${pi/2}"/>
-        <geometry>
-          <cylinder radius="${0.02+safety_distance}" length="0.1" />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 -0.05 0.1" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="${0.02+safety_distance}"  />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 0.05 0.1" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="${0.02+safety_distance}"  />
         </geometry>
       </collision>
     </link>
@@ -58,6 +40,24 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <origin xyz="0 0.0184 0.0101" rpy="0 0 0"/>
+        <geometry>
+          <box size="${0.022+safety_distance} ${0.014+safety_distance} ${0.0177+safety_distance}" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0.01655 0.02755" rpy="${3.257/(2*pi)} 0 0"/>
+        <geometry>
+          <box size="${0.022+safety_distance} ${0.00686+safety_distance} 0.0237" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0.0073 0.045" rpy="0 0 0"/>
+        <geometry>
+          <box size="${0.022+safety_distance} ${0.0147+safety_distance} ${0.0178+safety_distance}" />
+        </geometry>
+      </collision>
     </link>
     <link name="${ns}_rightfinger">
       <visual>
@@ -66,7 +66,25 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
-   </link>
+      <collision>
+        <origin xyz="0 -0.0184 0.0101" rpy="0 0 0"/>
+        <geometry>
+          <box size="${0.022+safety_distance} ${0.014+safety_distance} ${0.0177+safety_distance}" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 -0.01655 0.02755" rpy="${-3.257/(2*pi)} 0 0"/>
+        <geometry>
+          <box size="${0.022+safety_distance} ${0.00686+safety_distance} 0.0237" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 -0.0073 0.045" rpy="0 0 0"/>
+        <geometry>
+          <box size="${0.022+safety_distance} ${0.0147+safety_distance} ${0.0178+safety_distance}" />
+        </geometry>
+      </collision>
+    </link>
     <joint name="${ns}_finger_joint1" type="prismatic">
       <parent link="${ns}_hand"/>
       <child link="${ns}_leftfinger"/>


### PR DESCRIPTION
This commit replaces the finger collision geometries found in the hand joint with more accurate finger geometries placed in the finger joints.

#### Previous robot_description finger + hand geometries

##### Safety distance 0.03

![image](https://user-images.githubusercontent.com/17570430/129908063-e4be261b-3062-4848-b0f8-fa4015208a3a.png)

##### Safety distance 0.0

![image](https://user-images.githubusercontent.com/17570430/129908186-2b67af7a-11fe-40c4-aac4-8a87b9bd1b54.png)

#### New robot_description finger + hand geometries

##### Safety distance 0.03

![image](https://user-images.githubusercontent.com/17570430/129907712-01bd5af4-08ed-4e94-933f-908462afc661.png)

##### Safety distance 0.0

![image](https://user-images.githubusercontent.com/17570430/129907825-ff66fc08-b0c3-448f-88ce-c385f715bd22.png)
