### PR TITLE
Moves finger collision geometries to the finger joints

### DIFF
--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -33,24 +33,6 @@
           <sphere radius="${0.04+safety_distance}"  />
         </geometry>
       </collision>
-      <collision>
-        <origin xyz="0 0 0.1" rpy="0 ${pi/2} ${pi/2}"/>
-        <geometry>
-          <cylinder radius="${0.02+safety_distance}" length="0.1" />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 -0.05 0.1" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="${0.02+safety_distance}"  />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 0.05 0.1" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="${0.02+safety_distance}"  />
-        </geometry>
-      </collision>
     </link>
     <link name="${ns}_leftfinger">
       <visual>
@@ -58,6 +40,18 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <origin xyz="0 0.01 0.0415" rpy="0 0 0"/>
+        <geometry>
+          <sphere radius="${0.02+safety_distance}"  />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 -0.015 0.0416" rpy="0 ${pi/2} ${pi/2}"/>
+        <geometry>
+          <cylinder radius="${0.02+safety_distance}" length="0.05" />
+        </geometry>
+      </collision>
     </link>
     <link name="${ns}_rightfinger">
       <visual>
@@ -66,6 +60,18 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <origin xyz="0 -0.01 0.0415" rpy="0 0 0"/>
+        <geometry>
+          <sphere radius="${0.02+safety_distance}"  />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0.015 0.0416" rpy="0 ${pi/2} ${pi/2}"/>
+        <geometry>
+          <cylinder radius="${0.02+safety_distance}" length="0.05" />
+        </geometry>
+      </collision>
    </link>
     <joint name="${ns}_finger_joint1" type="prismatic">
       <parent link="${ns}_hand"/>


### PR DESCRIPTION
This commit moves the finger collision geometries to the finger joints. This was done to prevent errors in third party libraries. Moveit for example expects a collision geometry in each joint that can be controlled. You can see this behaviour by running the `panda_moveit_config demo.launch` launch file. If the old description is used moveIt throws the following errors:

```bash
[ WARN] [1629295377.872753565]: Link panda_leftfinger has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
[ WARN] [1629295377.872794348]: Link panda_rightfinger has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
```

#### Old collision meshes

##### Safety distance 0.03

*Open state*:

![image](https://user-images.githubusercontent.com/17570430/129914588-bf68c345-7ecd-4391-a627-e9618f0de030.png)

*Closed state*:

![image](https://user-images.githubusercontent.com/17570430/130058485-660f08b8-ef12-496c-b67b-ebd3ff1c1628.png)

##### Safety distance 0.0

![image](https://user-images.githubusercontent.com/17570430/129914798-16bf43c6-116f-40f9-a020-b60d3473056b.png)

#### New collision meshes

##### Safety distance 0.03

![image](https://user-images.githubusercontent.com/17570430/129914952-02fad410-4436-47aa-a708-184cf24bb1f4.png)

##### Safety distance 0.0

![image](https://user-images.githubusercontent.com/17570430/129915027-e4c0724c-ee63-42b8-940e-bf9db5f1f2b3.png)

