### PR TITLE
move finger collision geometry sparse

### DIFF
--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -33,24 +33,6 @@
           <sphere radius="${0.04+safety_distance}"  />
         </geometry>
       </collision>
-      <collision>
-        <origin xyz="0 0 0.1" rpy="0 ${pi/2} ${pi/2}"/>
-        <geometry>
-          <cylinder radius="${0.02+safety_distance}" length="0.1" />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 -0.05 0.1" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="${0.02+safety_distance}"  />
-        </geometry>
-      </collision>
-      <collision>
-        <origin xyz="0 0.05 0.1" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="${0.02+safety_distance}"  />
-        </geometry>
-      </collision>
     </link>
     <link name="${ns}_leftfinger">
       <visual>
@@ -58,6 +40,12 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <origin xyz="0 0.01 0.0415" rpy="0 0 0"/>
+        <geometry>
+          <sphere radius="${0.02+safety_distance}"  />
+        </geometry>
+      </collision>
     </link>
     <link name="${ns}_rightfinger">
       <visual>
@@ -66,6 +54,12 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <origin xyz="0 -0.01 0.0415" rpy="0 0 0"/>
+        <geometry>
+          <sphere radius="${0.02+safety_distance}"  />
+        </geometry>
+      </collision>
    </link>
     <joint name="${ns}_finger_joint1" type="prismatic">
       <parent link="${ns}_hand"/>


### PR DESCRIPTION
Similar to #151 but now the cylinder geometry between the two fingers have been removed.

#### New geometries

##### Safety distance 0.03

![image](https://user-images.githubusercontent.com/17570430/129915877-0246109f-9bf0-413b-a084-bc1dea0db16b.png)

##### Safety distance 0.0

![image](https://user-images.githubusercontent.com/17570430/129916081-a30ac7c9-d810-41bc-9708-b6cecb03d97e.png)

#### Old  geometries

##### Safety distance 0.03

![image](https://user-images.githubusercontent.com/17570430/129916241-87dcbc44-5973-452f-9aa1-9cec08059327.png)

##### Safety distance 0.0

![image](https://user-images.githubusercontent.com/17570430/129916293-c00149ca-14ac-4305-98b3-3d83778bdbf4.png)


