### PR TITLE
Adds the ability to specify the safety_distance

### DIFF
--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -4,17 +4,19 @@
   <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
   <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
   <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
+  <xacro:arg name="safety_distance" default="0.03" /> <!-- The safety distance that is used for the collisions. Please take care when changing this value!" -->
 
   <xacro:property name="arm_id" value="$(arg arm_id)" />
+  <xacro:property name="safety_distance" value="$(arg safety_distance)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
     <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro" />
-    <xacro:panda_arm arm_id="${arm_id}" safety_distance="0.03"/>
+    <xacro:panda_arm arm_id="${arm_id}" safety_distance="${safety_distance}"/>
 
     <xacro:if value="$(arg hand)">
       <xacro:include filename="$(find franka_description)/robots/hand.xacro"/>
-      <xacro:hand ns="${arm_id}" rpy="0 0 ${-pi/4}" connected_to="${arm_id}_link8" safety_distance="0.03"/>
+      <xacro:hand ns="${arm_id}" rpy="0 0 ${-pi/4}" connected_to="${arm_id}_link8" safety_distance="${safety_distance}"/>
     </xacro:if>
   </xacro:unless>
 


### PR DESCRIPTION
This pull request gives users the ability to specify the `safety_distance` when they load the robot xacro. This only changes the safety_distance in the `urdf` and does not affect the `safety_distance` in the internal controller.