### PR TITLE
Fixes hand real/gazebo discrepacy

### DIFF
--- a/franka_description/robots/panda_gazebo.xacro
+++ b/franka_description/robots/panda_gazebo.xacro
@@ -366,6 +366,7 @@
       <axis xyz="0 -1 0"/>
       <limit effort="20" lower="0.0" upper="0.04" velocity="0.2"/>
       <dynamics damping="0.3"/>
+      <mimic joint="${ns}_finger_joint1" />
     </joint>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This commit makes sure that the hand joint control behaviour between the real and simulated robot is equal. Previously the 'franka_finger_joint2' mimics the 'franka_finger_joint1' in the real robot but not in the simulation.

I think having the same behaviour in both the simulation and on the real robot makes sense since it otherwise might causes errors in third party packages controlling the robot.
