### PR TITLE
Adds the 'transmission' arg to the 'panda_arm.urdf.xacro' file

### DIFF
--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -1,12 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
 
-  <!-- Name of this panda -->
-  <xacro:arg name="arm_id" default="panda" />
-  <!-- Should a franka_gripper be mounted at the flange?" -->
-  <xacro:arg name="hand" default="false" />
-  <!-- Is the robot being simulated in gazebo?" -->
-  <xacro:arg name="gazebo" default="false" />
+  <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
+  <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
+  <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
+  <xacro:arg name="transmission" default="hardware_interface/EffortJointInterface" /> <!-- The transmission that is used in the gazebo joints -->
+
+  <xacro:property name="arm_id" value="$(arg arm_id)" />
+  <xacro:property name="transmission" value="$(arg transmission)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
@@ -45,13 +46,13 @@
     </joint>
 
 
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint1" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint2" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint3" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint4" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint5" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint6" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint7" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="${arm_id}_joint1" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint2" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint3" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint4" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint5" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint6" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint7" transmission="${transmission}" />
 
     <xacro:transmission-franka-state arm_id="$(arg arm_id)" />
     <xacro:transmission-franka-model arm_id="$(arg arm_id)"

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -4,10 +4,10 @@
   <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
   <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
   <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
-  <xacro:arg name="transmission" default="hardware_interface/EffortJointInterface" /> <!-- The transmission that is used in the gazebo joints -->
+  <!-- The transmission type that is used to control arm joints in gazebo: position, velocity, or effort -->
+  <xacro:arg name="transmission" default="effort" />
 
   <xacro:property name="arm_id" value="$(arg arm_id)" />
-  <xacro:property name="transmission" value="$(arg transmission)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
@@ -46,13 +46,20 @@
     </joint>
 
 
-    <xacro:gazebo-joint joint="${arm_id}_joint1" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint2" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint3" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint4" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint5" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint6" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint7" transmission="${transmission}" />
+    <xacro:property name="transmission" value="$(arg transmission)" />
+    <!-- sanity check -->
+    <xacro:if value="${transmission.lower() not in ['position', 'velocity', 'effort']}" >
+      ${xacro.fatal("transmission:=" + transmission + " is not one of position, velocity, or effort")}
+    </xacro:if>
+    <!-- Unify transmission argument into title case and expand to full name -->
+    <xacro:property name="transmission" value="hardware_interface/${transmission.title()}JointInterface" lazy_eval="false" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint1" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint2" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint3" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint4" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint5" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint6" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint7" transmission="${transmission}" />
 
     <xacro:transmission-franka-state arm_id="$(arg arm_id)" />
     <xacro:transmission-franka-model arm_id="$(arg arm_id)"

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -1,13 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
 
-  <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
-  <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
-  <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
+  <!-- Name of this panda -->
+  <xacro:arg name="arm_id" default="panda" />
+  <!-- Should a franka_gripper be mounted at the flange?" -->
+  <xacro:arg name="hand" default="false" />
+  <!-- Is the robot being simulated in gazebo?" -->
+  <xacro:arg name="gazebo" default="false" />
   <!-- The transmission type that is used to control arm joints in gazebo: position, velocity, or effort -->
   <xacro:arg name="transmission" default="effort" />
-
-  <xacro:property name="arm_id" value="$(arg arm_id)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -11,8 +11,8 @@
   <!-- Robot Customization -->
   <arg name="arm_id"      default="panda" doc="Name of the panda robot to spawn" />
   <arg name="use_gripper" default="true"  doc="Should a franka hand be mounted on the flange?" />
-  <arg name="transmission" default="effort" doc="Transmission type used for arm joints. One of position, velocity, effort." />
   <arg name="controller"  default=" "     doc="Which example controller should be started? (One of {cartesian_impedance,model,force}_example_controller)" />
+  <arg name="transmission" default="effort" doc="Transmission type used for arm joints. One of position, velocity, effort." />
   <arg name="x"           default="0"     doc="How far forward to place the base of the robot in [m]?" />
   <arg name="y"           default="0"     doc="How far leftwards to place the base of the robot in [m]?" />
   <arg name="z"           default="0"     doc="How far upwards to place the base of the robot in [m]?" />

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -11,6 +11,7 @@
   <!-- Robot Customization -->
   <arg name="arm_id"      default="panda" doc="Name of the panda robot to spawn" />
   <arg name="use_gripper" default="true"  doc="Should a franka hand be mounted on the flange?" />
+  <arg name="transmission" default="effort" doc="Transmission type used for arm joints. One of position, velocity, effort." />
   <arg name="controller"  default=" "     doc="Which example controller should be started? (One of {cartesian_impedance,model,force}_example_controller)" />
   <arg name="x"           default="0"     doc="How far forward to place the base of the robot in [m]?" />
   <arg name="y"           default="0"     doc="How far leftwards to place the base of the robot in [m]?" />
@@ -43,6 +44,7 @@
          command="xacro $(find franka_description)/robots/panda_arm.urdf.xacro
                   gazebo:=true
                   hand:=$(arg use_gripper)
+                  transmission:=$(arg transmission)
                   arm_id:=$(arg arm_id)
                   xyz:='$(arg x) $(arg y) $(arg z)'
                   rpy:='$(arg roll) $(arg pitch) $(arg yaw)'">


### PR DESCRIPTION
This commit gives users the ability to set the hardware_interface that is used in the panda arm joints when loading the `panda_arm.urdf.xacro` file. 