### PR TITLE
Add franka_vacuum_gripper package

### DIFF
--- a/franka_vacuum_gripper/CMakeLists.txt
+++ b/franka_vacuum_gripper/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.4)
+project(franka_vacuum_gripper)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  message_generation
+  control_msgs
+  actionlib
+  sensor_msgs
+  xmlrpcpp
+  actionlib_msgs
+)
+
+find_package(Franka 0.7.0 REQUIRED)
+
+add_action_files(
+  DIRECTORY action
+  FILES Vacuum.action
+        Stop.action
+	DropOff.action
+)
+
+generate_messages(DEPENDENCIES actionlib_msgs)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES franka_vacuum_gripper
+  CATKIN_DEPENDS roscpp
+                 message_runtime
+                 control_msgs
+                 actionlib
+                 sensor_msgs
+                 xmlrpcpp
+                 actionlib_msgs
+  DEPENDS Franka
+)
+
+add_library(franka_vacuum_gripper
+  src/franka_vacuum_gripper.cpp
+)
+
+add_dependencies(franka_vacuum_gripper
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+  ${PROJECT_NAME}_generate_messages_cpp
+)
+
+target_link_libraries(franka_vacuum_gripper
+  ${Franka_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
+target_include_directories(franka_vacuum_gripper SYSTEM PUBLIC
+  ${Franka_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+)
+target_include_directories(franka_vacuum_gripper PUBLIC
+  include
+)
+
+add_executable(franka_vacuum_gripper_node
+  src/franka_vacuum_gripper_node.cpp
+)
+
+add_dependencies(franka_vacuum_gripper_node
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+  franka_vacuum_gripper
+)
+
+target_link_libraries(franka_vacuum_gripper_node
+   ${catkin_LIBRARIES}
+   franka_vacuum_gripper
+)
+
+target_include_directories(franka_vacuum_gripper_node SYSTEM PUBLIC
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Installation
+install(TARGETS franka_vacuum_gripper
+                franka_vacuum_gripper_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+install(DIRECTORY config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+## Tools
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/ClangTools.cmake OPTIONAL
+  RESULT_VARIABLE CLANG_TOOLS
+)
+if(CLANG_TOOLS)
+  file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+  file(GLOB_RECURSE HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h
+  )
+  add_format_target(franka_vacuum_gripper FILES ${SOURCES} ${HEADERS})
+  add_tidy_target(franka_vacuum_gripper
+    FILES ${SOURCES}
+    DEPENDS franka_vacuum_gripper franka_vacuum_gripper_node
+  )
+endif()

--- a/franka_vacuum_gripper/LICENSE
+++ b/franka_vacuum_gripper/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/franka_vacuum_gripper/NOTICE
+++ b/franka_vacuum_gripper/NOTICE
@@ -1,0 +1,15 @@
+franka_ros
+
+Copyright 2017 Franka Emika GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/franka_vacuum_gripper/README.md
+++ b/franka_vacuum_gripper/README.md
@@ -1,0 +1,53 @@
+# Schmalz cobot vacuum gripper for FRANKA EMIKA Panda arm
+This package is written to allow for the control of the schmalz cobot  vacuum gripper designed for the Franka Emika Panda through ROS.
+
+It is in essence a copy of the [franka_gripper]() package, I simply changed some small things to point the methods to the vacuum gripper class already present in Libfranka (0.8.0).
+
+## Installation
+If libfranka and franka ros are not yet installed, do that first, following the steps as given by Franka Emika (add link)
+
+Once that is done, clone this package into your workspace
+```bash
+git clone (add link)
+```
+
+Then, build the package
+
+```bash
+catkin build -DCMAKE_BUILD_TYPE=Release -DFranka_DIR:PATH=path/to/libfranka/build franka_vacuum_gripper
+```
+
+## Usage
+Make sure the Schmalz cobot vacuum gripper is installed on the Franka Emika Panda arm as instructed and that the vacuum gripper is selected as being the current end-effector in the franka desk application.
+
+Launch the franka_vacuum_gripper_node
+```bash
+cd catkin_ws
+source devel/setup.bash
+roslaunch franka_vacuum_gripper franka_vacuum_gripper.launch robot_ip:=[your robot_ip]
+```
+
+This launches three different action services:
+1. vacuum  
+in: vacuum [per 10 mbar]
+in: timeout [ms]
+out: success [bool]
+out: error [string]
+
+This action will cause the gripper to apply a vacuum. As soon as the vacuum level is reached, the action succeeds.
+
+2. drop off
+in: timeout [ms]
+out: success [bool]
+out: error [string]
+
+This action will cause the gripper to stop applying the vacuum and, additionally, release the vacuum so that the grasped object drops.
+
+3. stop
+out: success [bool]
+out: error [string]
+
+This action will stop the gripper to apply a vacuum but as far as I understand it does not release the vacuum, causing the object to stay attached to the gripper.
+
+
+

--- a/franka_vacuum_gripper/action/DropOff.action
+++ b/franka_vacuum_gripper/action/DropOff.action
@@ -1,0 +1,5 @@
+int8 timeout
+---
+bool success
+string error
+---

--- a/franka_vacuum_gripper/action/Stop.action
+++ b/franka_vacuum_gripper/action/Stop.action
@@ -1,0 +1,4 @@
+---
+bool success
+string error
+---

--- a/franka_vacuum_gripper/action/Vacuum.action
+++ b/franka_vacuum_gripper/action/Vacuum.action
@@ -1,0 +1,6 @@
+int8 vacuum # [10 mbar]
+int8 timeout # [ms]
+---
+bool success
+string error
+---

--- a/franka_vacuum_gripper/config/franka_vacuum_gripper_node.yaml
+++ b/franka_vacuum_gripper/config/franka_vacuum_gripper_node.yaml
@@ -1,0 +1,1 @@
+publish_rate: 30  # [Hz]

--- a/franka_vacuum_gripper/include/franka_vacuum_gripper/franka_vacuum_gripper.h
+++ b/franka_vacuum_gripper/include/franka_vacuum_gripper/franka_vacuum_gripper.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Franka Emika GmbH
+// Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#pragma once
+
+#include <cmath>
+#include <string>
+
+#include <actionlib/server/simple_action_server.h>
+#include <ros/node_handle.h>
+
+#include <franka/exception.h>
+#include <franka/vacuum_gripper.h>
+#include <franka/vacuum_gripper_state.h>
+
+#include <franka_vacuum_gripper/StopAction.h>
+#include <franka_vacuum_gripper/VacuumAction.h>
+#include <franka_vacuum_gripper/DropOffAction.h>
+
+namespace franka_vacuum_gripper {
+
+/**
+ * Reads a vacuum gripper state if possible
+ *
+ * @param[in] state A gripper state to update
+ * @param[in] gripper A pointer to a franka gripper
+ *
+ * @return True if update was successful, false otherwise.
+ */
+bool updateGripperState(const franka::VacuumGripper& gripper, franka::VacuumGripperState* state);
+
+bool stop(const franka::VacuumGripper& gripper, const StopGoalConstPtr& /*goal*/);
+
+/**
+ * Calls the libfranka vacuum service of the vacuum gripper
+ *
+ * An object is considered grasped if the distance \f$d\f$ between the gripper fingers satisfies
+ * \f$(\text{width} - \text{epsilon_inner}) < d < (\text{width} + \text{epsilon_outer})\f$.
+ *
+ * @param[in] gripper A gripper instance to execute the command
+ * @param[in] goal A grasp goal with target vacuum and timeout
+ * @return True if an object has been vacuumed, false otherwise.
+ */
+bool vacuum(const franka::VacuumGripper& gripper, const VacuumGoalConstPtr& goal);
+
+/**
+ * Calls the libfranka drop off service of the vacuum gripper
+ *
+ * @param[in] gripper A gripper instance to execute the command
+ * @param[in] goal A dropoff goal with timeout
+ * @return True if an object has been dropped, false otherwise.
+ */
+bool dropOff(const franka::VacuumGripper& gripper, const DropOffGoalConstPtr& goal);
+
+}  // namespace franka_vacuum_gripper

--- a/franka_vacuum_gripper/launch/franka_vacuum_gripper.launch
+++ b/franka_vacuum_gripper/launch/franka_vacuum_gripper.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<launch>
+  <arg name="robot_ip" />
+  <arg name="stop_at_shutdown" default="false" />
+  <arg name="arm_id"      default="panda" />
+
+  <node name="franka_vacuum_gripper" pkg="franka_vacuum_gripper" type="franka_vacuum_gripper_node" output="screen">
+    <param name="robot_ip" value="$(arg robot_ip)"/>
+    <param name="stop_at_shutdown" value="$(arg stop_at_shutdown)" />
+    <rosparam command="load" file="$(find franka_vacuum_gripper)/config/franka_vacuum_gripper_node.yaml" />
+  </node>
+
+</launch>

--- a/franka_vacuum_gripper/mainpage.dox
+++ b/franka_vacuum_gripper/mainpage.dox
@@ -1,0 +1,6 @@
+/**
+ * @mainpage
+ * @htmlinclude "manifest.html"
+ *
+ * Overview page for Franka Emika research robots: https://frankaemika.github.io
+ */

--- a/franka_vacuum_gripper/package.xml
+++ b/franka_vacuum_gripper/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>franka_vacuum_gripper</name>
+  <version>0.8.0</version>
+  <description>This package implements the Schmalz cobot vacuum pump for the use in ros</description>
+  <maintainer email="s.d.bonhof@gmail.com">Stefan Bonhof</maintainer>
+  <license>Apache 2.0</license>
+
+  <url type="repository">https://github.com/SDBonhof/franka_vacuum_gripper</url>
+  <url type="bugtracker">https://github.com/SDBonhof/franka_vacuum_gripper/issues</url>
+  <author>Stefan Bonhof</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>roscpp</depend>
+  <depend>message_generation</depend>
+  <depend>libfranka</depend>
+  <depend>control_msgs</depend>
+  <depend>actionlib</depend>
+  <depend>sensor_msgs</depend>
+  <depend>xmlrpcpp</depend>
+  <depend>actionlib_msgs</depend>
+
+  <exec_depend>message_runtime</exec_depend>
+
+  <build_export_depend>message_runtime</build_export_depend>
+</package>

--- a/franka_vacuum_gripper/package.xml
+++ b/franka_vacuum_gripper/package.xml
@@ -3,12 +3,13 @@
   <name>franka_vacuum_gripper</name>
   <version>0.8.0</version>
   <description>This package implements the Schmalz cobot vacuum pump for the use in ros</description>
-  <maintainer email="s.d.bonhof@gmail.com">Stefan Bonhof</maintainer>
+  <maintainer email="support@franka.de">Franka Emika GmbH</maintainer>
   <license>Apache 2.0</license>
 
-  <url type="repository">https://github.com/SDBonhof/franka_vacuum_gripper</url>
-  <url type="bugtracker">https://github.com/SDBonhof/franka_vacuum_gripper/issues</url>
-  <author>Stefan Bonhof</author>
+  <url type="website">http://wiki.ros.org/franka_gripper</url>
+  <url type="repository">https://github.com/frankaemika/franka_ros</url>
+  <url type="bugtracker">https://github.com/frankaemika/franka_ros/issues</url>
+  <author>Franka Emika GmbH</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/franka_vacuum_gripper/rosdoc.yaml
+++ b/franka_vacuum_gripper/rosdoc.yaml
@@ -1,0 +1,2 @@
+- builder: doxygen
+  javadoc_autobrief: YES

--- a/franka_vacuum_gripper/src/franka_vacuum_gripper.cpp
+++ b/franka_vacuum_gripper/src/franka_vacuum_gripper.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Franka Emika GmbH
+// Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#include <franka_vacuum_gripper/franka_vacuum_gripper.h>
+
+#include <cmath>
+#include <functional>
+#include <thread>
+#include <chrono>
+
+#include <ros/node_handle.h>
+
+#include <franka/exception.h>
+#include <franka/vacuum_gripper_state.h>
+#include <franka_vacuum_gripper/VacuumAction.h>
+#include <franka_vacuum_gripper/StopAction.h>
+#include <franka_vacuum_gripper/DropOffAction.h>
+
+
+namespace franka_vacuum_gripper {
+
+bool updateGripperState(const franka::VacuumGripper& gripper, franka::VacuumGripperState* state) {
+  try {
+    *state = gripper.readOnce();
+  } catch (const franka::Exception& ex) {
+    ROS_ERROR_STREAM("GripperServer: Exception reading gripper state: " << ex.what());
+    return false;
+  }
+  return true;
+}
+
+bool stop(const franka::VacuumGripper& gripper, const StopGoalConstPtr& /*goal*/) {
+  return gripper.stop();
+}
+
+bool vacuum(const franka::VacuumGripper& gripper, const VacuumGoalConstPtr& goal) {
+	// Transform timeout in int8 to std::chrono::milliseconds
+	std::chrono::milliseconds timeout_ms(goal->timeout);
+  return gripper.vacuum(goal->vacuum, timeout_ms);
+}
+
+bool dropOff(const franka::VacuumGripper& gripper, const DropOffGoalConstPtr& goal) {
+	// Transform timeout in int8 to std::chrono::milliseconds
+	std::chrono::milliseconds timeout_ms(goal->timeout);
+  return gripper.dropOff(timeout_ms);
+}
+}  // namespace franka_gripper

--- a/franka_vacuum_gripper/src/franka_vacuum_gripper_node.cpp
+++ b/franka_vacuum_gripper/src/franka_vacuum_gripper_node.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2017 Franka Emika GmbH
+// Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <ros/init.h>
+#include <ros/node_handle.h>
+#include <ros/rate.h>
+#include <ros/spinner.h>
+
+#include <franka/vacuum_gripper_state.h>
+#include <franka_vacuum_gripper/franka_vacuum_gripper.h>
+
+#include <franka_vacuum_gripper/StopAction.h>
+#include <franka_vacuum_gripper/VacuumAction.h>
+#include <franka_vacuum_gripper/DropOffAction.h>
+
+namespace {
+
+template <typename T_action, typename T_goal, typename T_result>
+void handleErrors(actionlib::SimpleActionServer<T_action>* server,
+                  std::function<bool(const T_goal&)> handler,
+                  const T_goal& goal) {
+  T_result result;
+  try {
+    result.success = handler(goal);
+    server->setSucceeded(result);
+  } catch (const franka::Exception& ex) {
+    ROS_ERROR_STREAM("" << ex.what());
+    result.success = false;
+    result.error = ex.what();
+    server->setAborted(result);
+  }
+}
+
+}  // anonymous namespace
+
+using actionlib::SimpleActionServer;
+
+using franka_vacuum_gripper::vacuum;
+using franka_vacuum_gripper::VacuumAction;
+
+using franka_vacuum_gripper::stop;
+using franka_vacuum_gripper::StopAction;
+using franka_vacuum_gripper::StopGoalConstPtr;
+using franka_vacuum_gripper::StopResult;
+
+using franka_vacuum_gripper::dropOff;
+using franka_vacuum_gripper::DropOffAction;
+
+using franka_vacuum_gripper::updateGripperState;
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "franka_vacuum_gripper_node");
+  ros::NodeHandle node_handle("~");
+  std::string robot_ip;
+  if (!node_handle.getParam("robot_ip", robot_ip)) {
+    ROS_ERROR("franka_gripper_node: Could not parse robot_ip parameter");
+    return -1;
+  }
+
+  franka::VacuumGripper gripper(robot_ip);
+
+  auto stop_handler = [&gripper](auto&& goal) { return stop(gripper, goal); };
+  auto vacuum_handler = [&gripper](auto&& goal) { return vacuum(gripper, goal); };
+  auto dropoff_handler = [&gripper](auto&& goal) {return dropOff(gripper, goal); }; 
+
+  SimpleActionServer<StopAction> stop_action_server(
+      node_handle, "stop",
+      [=, &stop_action_server](auto&& goal) {
+        return handleErrors<franka_vacuum_gripper::StopAction, franka_vacuum_gripper::StopGoalConstPtr,
+                            franka_vacuum_gripper::StopResult>(&stop_action_server, stop_handler, goal);
+      },
+      false);
+
+  SimpleActionServer<VacuumAction> vacuum_action_server(
+      node_handle, "vacuum",
+      [=, &vacuum_action_server](auto&& goal) {
+        return handleErrors<franka_vacuum_gripper::VacuumAction, franka_vacuum_gripper::VacuumGoalConstPtr,
+                            franka_vacuum_gripper::VacuumResult>(&vacuum_action_server, vacuum_handler, goal);
+      },
+      false);
+
+  SimpleActionServer<DropOffAction> dropoff_action_server(
+      node_handle, "dropoff",
+      [=, &dropoff_action_server](auto&& goal) {
+        return handleErrors<franka_vacuum_gripper::DropOffAction, franka_vacuum_gripper::DropOffGoalConstPtr,
+                            franka_vacuum_gripper::DropOffResult>(&dropoff_action_server, dropoff_handler, goal);
+      },
+      false);
+
+
+  stop_action_server.start();
+  vacuum_action_server.start();
+  dropoff_action_server.start();
+
+  double publish_rate(30.0);
+  if (!node_handle.getParam("publish_rate", publish_rate)) {
+    ROS_INFO_STREAM("franka_gripper_node: Could not find parameter publish_rate. Defaulting to "
+                    << publish_rate);
+  }
+
+  bool stop_at_shutdown(false);
+  if (!node_handle.getParam("stop_at_shutdown", stop_at_shutdown)) {
+    ROS_INFO_STREAM("franka_gripper_node: Could not find parameter stop_at_shutdown. Defaulting to "
+                    << std::boolalpha << stop_at_shutdown);
+  }
+
+  franka::VacuumGripperState gripper_state;
+  std::mutex gripper_state_mutex;
+  std::thread read_thread([&gripper_state, &gripper, &gripper_state_mutex]() {
+    ros::Rate read_rate(10);
+    while (ros::ok()) {
+      {
+        std::lock_guard<std::mutex> _(gripper_state_mutex);
+        updateGripperState(gripper, &gripper_state);
+      }
+      read_rate.sleep();
+    }
+  });
+
+  ros::AsyncSpinner spinner(2);
+  spinner.start();
+  ros::Rate rate(publish_rate);
+  while (ros::ok()) {
+    if (gripper_state_mutex.try_lock()) {
+      gripper_state_mutex.unlock();  
+    }
+    rate.sleep();
+  }
+  read_thread.join();
+  if (stop_at_shutdown) {
+    gripper.stop();
+  }
+  return 0;
+}

--- a/franka_vacuum_gripper/src/franka_vacuum_gripper_node_new.cpp
+++ b/franka_vacuum_gripper/src/franka_vacuum_gripper_node_new.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2017 Franka Emika GmbH
+// Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <ros/init.h>
+#include <ros/node_handle.h>
+#include <ros/rate.h>
+#include <ros/spinner.h>
+
+#include <franka/vacuum_gripper_state.h>
+#include <franka_vacuum_gripper/franka_vacuum_gripper.h>
+
+#include <franka_vacuum_gripper/StopAction.h>
+#include <franka_vacuum_gripper/VacuumAction.h>
+
+namespace {
+
+template <typename T_action, typename T_goal, typename T_result>
+void handleErrors(actionlib::SimpleActionServer<T_action>* server,
+                  std::function<bool(const T_goal&)> handler,
+                  const T_goal& goal) {
+  T_result result;
+  try {
+    ROS_WARN_STREAM("IN ACTION");
+    result.success = handler(goal);
+    server->setSucceeded(result);
+  } catch (const franka::Exception& ex) {
+    ROS_ERROR_STREAM("" << ex.what());
+    result.success = false;
+    result.error = ex.what();
+    server->setAborted(result);
+  }
+}
+
+}  // anonymous namespace
+
+using actionlib::SimpleActionServer;
+using franka_vacuum_gripper::vacuum;
+using franka_vacuum_gripper::VacuumAction;
+using franka_vacuum_gripper::stop;
+using franka_vacuum_gripper::StopAction;
+using franka_vacuum_gripper::StopGoalConstPtr;
+using franka_vacuum_gripper::StopResult;
+using franka_vacuum_gripper::updateGripperState;
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "franka_vacuum_gripper_node");
+  ros::NodeHandle node_handle("~");
+  std::string robot_ip;
+  if (!node_handle.getParam("robot_ip", robot_ip)) {
+    ROS_ERROR("franka_gripper_node: Could not parse robot_ip parameter");
+    return -1;
+  }
+
+  franka::VacuumGripper gripper(robot_ip);
+
+  auto stop_handler = [&gripper](auto&& goal) { return stop(gripper, goal); };
+  auto vacuum_handler = [&gripper](auto&& goal) { return vacuum(gripper, goal); };
+
+  SimpleActionServer<StopAction> stop_action_server(
+      node_handle, "stop",
+      [=, &stop_action_server](auto&& goal) {
+        return handleErrors<franka_vacuum_gripper::StopAction, franka_vacuum_gripper::StopGoalConstPtr,
+                            franka_vacuum_gripper::StopResult>(&stop_action_server, stop_handler, goal);
+      },
+      false);
+
+  SimpleActionServer<VacuumAction> vacuum_action_server(
+      node_handle, "vacuum",
+      [=, &vacuum_action_server](auto&& goal) {
+        return handleErrors<franka_vacuum_gripper::VacuumAction, franka_vacuum_gripper::VacuumGoalConstPtr,
+                            franka_vacuum_gripper::VacuumResult>(&vacuum_action_server, vacuum_handler, goal);
+      },
+      false);
+
+  stop_action_server.start();
+  vacuum_action_server.start();
+  ROS_WARN_STREAM("started stop and vacuum action servers");
+
+  double publish_rate(30.0);
+  if (!node_handle.getParam("publish_rate", publish_rate)) {
+    ROS_INFO_STREAM("franka_gripper_node: Could not find parameter publish_rate. Defaulting to "
+                    << publish_rate);
+  }
+
+  bool stop_at_shutdown(false);
+  if (!node_handle.getParam("stop_at_shutdown", stop_at_shutdown)) {
+    ROS_INFO_STREAM("franka_gripper_node: Could not find parameter stop_at_shutdown. Defaulting to "
+                    << std::boolalpha << stop_at_shutdown);
+  }
+
+  franka::VacuumGripperState gripper_state;
+  std::mutex gripper_state_mutex;
+  std::thread read_thread([&gripper_state, &gripper, &gripper_state_mutex]() {
+    ros::Rate read_rate(10);
+    while (ros::ok()) {
+      {
+        std::lock_guard<std::mutex> _(gripper_state_mutex);
+        updateGripperState(gripper, &gripper_state);
+      }
+      read_rate.sleep();
+    }
+  });
+
+  ros::Publisher gripper_state_publisher =
+	  node_handle.advertise<std::string>("gripper_state", 1);
+  ros::AsyncSpinner spinner(2);
+  spinner.start();
+  ros::Rate rate(publish_rate);
+
+  while (ros::ok()) {
+    if (gripper_state_mutex.try_lock()) {
+      std::string state_string;
+      state_string = "test";
+      gripper_state_publisher.publish(state_string);
+      gripper_state_mutex.unlock();
+    }
+    rate.sleep();
+  }
+  read_thread.join();
+  if (stop_at_shutdown) {
+    gripper.stop();
+  }
+  return 0;
+}
+


### PR DESCRIPTION
Added a package to control the Schmalz cobot vacuum gripper that is designed for the franka emika panda. Even though the vacuum gripper is designed for the franka panda, and an interface to the vacuum gripper was already present in libfranka, there was no easy way to use the vacuum gripper with ros like the parallel gripper can. 

I mainly copied the franka_gripper package and changed some things to match the vacuum gripper and it works great, at least on melodic with libfranka 0.8.0.

