### PR TITLE
Fixes franka_gripper_sim GripperCommand action

### DIFF
--- a/franka_gazebo/config/franka_hw_sim.yaml
+++ b/franka_gazebo/config/franka_hw_sim.yaml
@@ -1,9 +1,9 @@
 arm_id: $(arg arm_id)
 
-m_ee:  0.76
+m_ee: 0.76
 franka_gripper:
-  type:    franka_gazebo/FrankaGripperSim
-  arm_id:  $(arg arm_id)
+  type: franka_gazebo/FrankaGripperSim
+  arm_id: $(arg arm_id)
 
   finger1:
     gains: { p: 100, i: 25, d: 20 }


### PR DESCRIPTION
This commit makes sure that users can also send gripper widths between `0.0` and `0.08`. In the old version the gripper would only open and close based on whether the set gripper width was smaller or bigger than the current width.

I explained the problem in #172.