### PR TITLE
fix: adds gazebo gravity vector to the gravity calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * **BREAKING** Make `/panda` namespace of `franka_gazebo` optional
 * Add effort joint trajectory controller to be used by MoveIT
 * Make finger collisions primitive in `franka_gazebo`
+* add 'gravity_vector' gravity ROS parameter to FrankaHWSim
 
 ## 0.8.1 - 2021-09-08
 

--- a/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
@@ -90,6 +90,8 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
   void eStopActive(const bool active) override;
 
  private:
+  std::array<double, 3> gravity_earth_;
+
   std::string arm_id_;
   gazebo::physics::ModelPtr robot_;
   std::map<std::string, std::shared_ptr<franka_gazebo::Joint>> joints_;


### PR DESCRIPTION
This pull request makes sure that the gravity calculation uses the gravity vector that comes from the Gazebo simulation. 

In the old version the default value set in the [model_base.h](https://github.com/frankaemika/franka_ros/blob/1922fc9d24e37b2a8226c522e736eaa9a65d66ca/franka_hw/include/franka_hw/model_base.h) class was used (i.e. `[0, 0, -9.81]`) while gazebo uses the following gravity vector `[0, 0, -9.8000000000000007]`.

https://github.com/frankaemika/franka_ros/blob/1922fc9d24e37b2a8226c522e736eaa9a65d66ca/franka_hw/include/franka_hw/model_base.h#L236-L238

This is because the `gravity_earth` argument is not used.

https://github.com/frankaemika/franka_ros/blob/1922fc9d24e37b2a8226c522e736eaa9a65d66ca/franka_gazebo/src/franka_hw_sim.cpp#L306

### Other todos
- [ ] Update documentation.