### PR TITLE
Adds position and velocity motion generators to FrankaHWSim

### DIFF
--- a/franka_gazebo/config/franka_hw_sim.yaml
+++ b/franka_gazebo/config/franka_hw_sim.yaml
@@ -11,3 +11,26 @@ franka_gripper:
 
   finger2:
     gains: { p: 100, i: 0, d: 1.0 }
+
+# Motion generators PID gains
+# NOTE: Needed since the gazebo_ros_control currently only directly support effort hardware
+# interfaces (see #161).
+motion_generators:
+  position:
+    gains:
+      panda_joint1: { p: 600, d: 30, i: 0 }
+      panda_joint2: { p: 600, d: 30, i: 0 }
+      panda_joint3: { p: 600, d: 30, i: 0 }
+      panda_joint4: { p: 600, d: 30, i: 0 }
+      panda_joint5: { p: 250, d: 10, i: 0 }
+      panda_joint6: { p: 150, d: 10, i: 0 }
+      panda_joint7: { p:  50, d:  5, i: 0 }
+  velocity:
+    gains:
+      panda_joint1: { p: 600, d: 30, i: 0 }
+      panda_joint2: { p: 600, d: 30, i: 0 }
+      panda_joint3: { p: 600, d: 30, i: 0 }
+      panda_joint4: { p: 600, d: 30, i: 0 }
+      panda_joint5: { p: 250, d: 10, i: 0 }
+      panda_joint6: { p: 150, d: 10, i: 0 }
+      panda_joint7: { p:  50, d:  5, i: 0 }

--- a/franka_gazebo/config/sim_controllers.yaml
+++ b/franka_gazebo/config/sim_controllers.yaml
@@ -66,3 +66,23 @@ effort_joint_trajectory_controller:
     $(arg arm_id)_joint5: { goal: 0.05 }
     $(arg arm_id)_joint6: { goal: 0.05 }
     $(arg arm_id)_joint7: { goal: 0.05 }
+
+position_joint_trajectory_controller:
+  type: position_controllers/JointTrajectoryController
+  joints:
+    - $(arg arm_id)_joint1
+    - $(arg arm_id)_joint2
+    - $(arg arm_id)_joint3
+    - $(arg arm_id)_joint4
+    - $(arg arm_id)_joint5
+    - $(arg arm_id)_joint6
+    - $(arg arm_id)_joint7
+  constraints:
+    goal_time: 0.5
+    $(arg arm_id)_joint1: { goal: 0.05}
+    $(arg arm_id)_joint2: { goal: 0.05}
+    $(arg arm_id)_joint3: { goal: 0.05}
+    $(arg arm_id)_joint4: { goal: 0.05}
+    $(arg arm_id)_joint5: { goal: 0.05}
+    $(arg arm_id)_joint6: { goal: 0.05}
+    $(arg arm_id)_joint7: { goal: 0.05}

--- a/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <control_toolbox/pid.h>
 #include <franka/robot_state.h>
 #include <franka_gazebo/joint.h>
 #include <franka_hw/franka_model_interface.h>
@@ -31,6 +32,8 @@ const double kDefaultTauExtLowpassFilter = 1.0;  // no filtering per default of 
  * ### transmission_interface/SimpleTransmission
  * - hardware_interface/JointStateInterface
  * - hardware_interface/EffortJointInterface
+ * - hardware_interface/PositionJointInterface
+ * - hardware_interface/VelocityJointInterface
  *
  * ### franka_hw/FrankaStateInterface
  * ### franka_hw/FrankaModelInterface
@@ -101,8 +104,14 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
   gazebo::physics::ModelPtr robot_;
   std::map<std::string, std::shared_ptr<franka_gazebo::Joint>> joints_;
 
+  enum ControlMethod { EFFORT, POSITION, VELOCITY };
+  std::map<std::string, ControlMethod> joint_control_methods_;
+  std::map<std::string, control_toolbox::Pid> pid_controllers_;
+
   hardware_interface::JointStateInterface jsi_;
   hardware_interface::EffortJointInterface eji_;
+  hardware_interface::PositionJointInterface pji_;
+  hardware_interface::VelocityJointInterface vji_;
   franka_hw::FrankaStateInterface fsi_;
   franka_hw::FrankaModelInterface fmi_;
 
@@ -121,6 +130,8 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
 
   void initJointStateHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
   void initEffortCommandHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
+  void initPositionCommandHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
+  void initVelocityCommandHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
   void initFrankaStateHandle(const std::string& robot,
                              const urdf::Model& urdf,
                              const transmission_interface::TransmissionInfo& transmission);

--- a/franka_gazebo/include/franka_gazebo/joint.h
+++ b/franka_gazebo/include/franka_gazebo/joint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <angles/angles.h>
+#include <joint_limits_interface/joint_limits.h>
 #include <ros/ros.h>
 #include <Eigen/Dense>
 #include <gazebo/physics/Joint.hh>
@@ -34,6 +35,10 @@ struct Joint {
   /// The type of joint, i.e. revolute, prismatic, ... @see
   /// http://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1Joint.html
   int type;
+
+  /// Joint limits @see
+  /// https://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1JointLimits.html
+  joint_limits_interface::JointLimits limits;
 
   /// The axis of rotation/translation of this joint in local coordinates
   Eigen::Vector3d axis;


### PR DESCRIPTION
This pull request adds the `hardware_interface/PositionJointInterface'`and `hardware_interface/VelocityJointInterface` interfaces to the `FrankaHWSim` module. When a user chooses these interfaces, motion generators (i.e. PID controllers) are used for controlling the robot.

- This pull request requires #157 to be merged first.
- I did not extensively tune the PID gains of the motion generators, but they seem to work. Feel free to adjust them further.
- There is one minor bug in the current implementation that you might want to solve in future versions. The arm moves slightly at the beginning of the simulation when the position and velocity motion generators are used. This is probably because the joint commands are not initialized to the starting joint angles but to `0`. As I'm a bit short on time, I did not investigate this issue further. #181 is, in my opinion, good enough for releasing the Noetic version of the panda_moveit_config.

### TODOS

- [ ] Tune PID gains of the motion generators if you want smoother behaviour.
- [ ] Adjust the  trajectory controller goal tolerance  (see https://github.com/frankaemika/franka_ros/issues/201).

### Other TODOS
- [ ] Update documentation.