### PR TITLE
Add a JointTrajectoryController config

### DIFF
--- a/franka_control/config/default_controllers.yaml
+++ b/franka_control/config/default_controllers.yaml
@@ -1,4 +1,4 @@
-position_joint_trajectory_controller:
+joint_trajectory_controller:
   type: position_controllers/JointTrajectoryController
   joints:
     - panda_joint1

--- a/franka_control/config/default_controllers.yaml
+++ b/franka_control/config/default_controllers.yaml
@@ -1,4 +1,4 @@
-joint_trajectory_controller:
+position_joint_trajectory_controller: &default_trajectory_controller
   type: position_controllers/JointTrajectoryController
   joints:
     - panda_joint1
@@ -24,6 +24,9 @@ joint_trajectory_controller:
       goal: 0.05
     panda_joint7:
       goal: 0.05
+
+# define default controller for panda_moveit_config:
+joint_trajectory_controller: *default_trajectory_controller
 
 franka_state_controller:
   type: franka_control/FrankaStateController

--- a/franka_gazebo/config/sim_controllers.yaml
+++ b/franka_gazebo/config/sim_controllers.yaml
@@ -11,6 +11,26 @@ franka_state_controller:
     - $(arg arm_id)_joint6
     - $(arg arm_id)_joint7
 
+effort_joint_trajectory_controller:
+  type: effort_controllers/JointTrajectoryController
+  joints:
+    - $(arg arm_id)_joint1
+    - $(arg arm_id)_joint2
+    - $(arg arm_id)_joint3
+    - $(arg arm_id)_joint4
+    - $(arg arm_id)_joint5
+    - $(arg arm_id)_joint6
+    - $(arg arm_id)_joint7
+  gains:
+    $(arg arm_id)_joint1: { p: 600, d: 30, i: 0 }
+    $(arg arm_id)_joint2: { p: 600, d: 30, i: 0 }
+    $(arg arm_id)_joint3: { p: 600, d: 30, i: 0 }
+    $(arg arm_id)_joint4: { p: 600, d: 30, i: 0 }
+    $(arg arm_id)_joint5: { p: 250, d: 10, i: 0 }
+    $(arg arm_id)_joint6: { p: 150, d: 10, i: 0 }
+    $(arg arm_id)_joint7: { p:  50, d:  5, i: 0 }
+
+
 model_example_controller:
   type: franka_example_controllers/ModelExampleController
   arm_id: $(arg arm_id)

--- a/franka_gazebo/config/sim_controllers.yaml
+++ b/franka_gazebo/config/sim_controllers.yaml
@@ -11,7 +11,7 @@ franka_state_controller:
     - $(arg arm_id)_joint6
     - $(arg arm_id)_joint7
 
-joint_trajectory_controller:
+effort_joint_trajectory_controller: &default_trajectory_controller
   type: effort_controllers/JointTrajectoryController
   joints:
     - $(arg arm_id)_joint1
@@ -30,6 +30,8 @@ joint_trajectory_controller:
     $(arg arm_id)_joint6: { p: 150, d: 10, i: 0 }
     $(arg arm_id)_joint7: { p:  50, d:  5, i: 0 }
 
+# define default controller for panda_moveit_config:
+joint_trajectory_controller: *default_trajectory_controller
 
 model_example_controller:
   type: franka_example_controllers/ModelExampleController

--- a/franka_gazebo/config/sim_controllers.yaml
+++ b/franka_gazebo/config/sim_controllers.yaml
@@ -11,7 +11,7 @@ franka_state_controller:
     - $(arg arm_id)_joint6
     - $(arg arm_id)_joint7
 
-effort_joint_trajectory_controller:
+joint_trajectory_controller:
   type: effort_controllers/JointTrajectoryController
   joints:
     - $(arg arm_id)_joint1


### PR DESCRIPTION
Usage:
`roslaunch franka_gazebo panda.launch controller:=effort_joint_trajectory_controller`

Instead of stating the transmission type in the controller name, I suggest using just `joint_trajectory_controller`, here as well as in `default_controllers.yaml`:
https://github.com/frankaemika/franka_ros/blob/041d3eb36749cb2afdba8ed21555b306ee6dab04/franka_control/config/default_controllers.yaml#L1

![image](https://user-images.githubusercontent.com/5376030/139144972-f3ef739d-d042-46a2-8406-aa955aa865bf.png)
