### PR TITLE
Rework hand collision

### DIFF
--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -12,9 +12,16 @@
     <link name="${ns}_hand">
       <visual>
         <geometry>
-          <mesh filename="package://franka_description/meshes/visual/hand.dae"/>
+          <mesh filename="package://franka_description/meshes/visual/hand.dae" />
         </geometry>
       </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://franka_description/meshes/collision/hand.stl" />
+        </geometry>
+      </collision>
+    </link>
+    <link name="${ns}_hand_coarse">
       <collision>
         <origin xyz="0 0 0.04" rpy="0 ${pi/2} ${pi/2}"/>
         <geometry>
@@ -52,6 +59,10 @@
         </geometry>
       </collision>
     </link>
+    <joint name="${ns}_hand_coarse_joint" type="fixed">
+      <parent link="${ns}_hand" />
+      <child link="${ns}_hand_coarse" />
+    </joint>
     <link name="${ns}_leftfinger">
       <visual>
         <geometry>

--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -58,6 +58,11 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://franka_description/meshes/collision/finger.stl" />
+        </geometry>
+      </collision>
     </link>
     <link name="${ns}_rightfinger">
       <visual>
@@ -66,6 +71,12 @@
           <mesh filename="package://franka_description/meshes/visual/finger.dae"/>
         </geometry>
       </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 ${pi}" />
+        <geometry>
+          <mesh filename="package://franka_description/meshes/collision/finger.stl" />
+        </geometry>
+      </collision>
    </link>
     <joint name="${ns}_finger_joint1" type="prismatic">
       <parent link="${ns}_hand"/>

--- a/franka_description/robots/panda_gazebo.xacro
+++ b/franka_description/robots/panda_gazebo.xacro
@@ -300,6 +300,11 @@
                                           izz="0.0017" />
       </inertial>
     </link>
+    <link name="${ns}_hand_coarse" />
+    <joint name="${ns}_hand_coarse_joint" type="fixed">
+      <parent link="${ns}_hand" />
+      <child link="${ns}_hand_coarse" />
+    </joint>
 
     <link name="${ns}_leftfinger">
       <xacro:inertia-cylinder mass="15e-3" radius="0.01" h="0.04"/>


### PR DESCRIPTION
This is part of implementing https://github.com/ros-planning/moveit/issues/2936, i.e. providing two separate links for detailed and coarse hand collision:
- `panda_hand` uses the detailed .stl mesh to enable collision checking with the environment
- `panda_hand_coarse` uses coarse geometries to mimic self-collision checking of the internal controller

This goes in line with https://github.com/ros-planning/panda_moveit_config/pull/95.