### PR TITLE
Define finger_joint2 as mimic joint of finger_joint1

### DIFF
--- a/franka_description/robots/panda_gazebo.xacro
+++ b/franka_description/robots/panda_gazebo.xacro
@@ -382,6 +382,7 @@
       <axis xyz="0 -1 0"/>
       <limit effort="20" lower="0.0" upper="0.04" velocity="0.2"/>
       <dynamics friction="0.0" damping="0.03"/>
+      <mimic joint="${ns}_finger_joint1" />
     </joint>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Although, Gazebo doesn't support mimic joints natively, `FrankaHWSim` does and MoveIt - for planning - should know as well
that the fingers will move in sync.