### PR TITLE
Drop re-publishing of joint_states_desired

### DIFF
--- a/franka_control/launch/franka_control.launch
+++ b/franka_control/launch/franka_control.launch
@@ -22,10 +22,4 @@
     <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states] </rosparam>
     <param name="rate" value="30"/>
   </node>
-  <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <rosparam if="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-    <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states_desired] </rosparam>
-    <param name="rate" value="30"/>
-    <remap from="/joint_states" to="/joint_states_desired" />
-  </node>
 </launch>

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -80,11 +80,6 @@
     <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
     <param name="rate" value="30"/>
   </node>
-  <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-    <rosparam param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-    <param name="rate" value="30"/>
-    <remap from="joint_states" to="joint_states_desired" />
-  </node>
 
   <!-- Start only if cartesian_impedance_example_controller -->
   <node name="interactive_marker"


### PR DESCRIPTION
As discussed in https://github.com/rhaschke/panda_moveit_config/issues/12, joint_states_desired is not needed for MoveIt. 
Also, re-publishing like done here, is highly inefficient as `joint_state_publisher` is a python script!