### PR TITLE
Remap joint states instead of re-publish

### DIFF
--- a/franka_control/launch/franka_control.launch
+++ b/franka_control/launch/franka_control.launch
@@ -22,10 +22,4 @@
     <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states] </rosparam>
     <param name="rate" value="30"/>
   </node>
-  <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <rosparam if="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-    <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states_desired] </rosparam>
-    <param name="rate" value="30"/>
-    <remap from="/joint_states" to="/joint_states_desired" />
-  </node>
 </launch>

--- a/franka_control/launch/franka_control.launch
+++ b/franka_control/launch/franka_control.launch
@@ -5,6 +5,10 @@
 
   <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
 
+  <!-- Remap both, arm and gripper joint states to default ROS topic joint_states -->
+  <remap from="franka_state_controller/joint_states" to="joint_states" />
+  <remap from="franka_gripper/joint_states" to="joint_states" />
+
   <include file="$(find franka_gripper)/launch/franka_gripper.launch" if="$(arg load_gripper)">
     <arg name="robot_ip" value="$(arg robot_ip)" />
   </include>
@@ -17,9 +21,4 @@
   <rosparam command="load" file="$(find franka_control)/config/default_controllers.yaml" />
   <node name="state_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="franka_state_controller"/>
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
-  <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <rosparam if="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
-    <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states] </rosparam>
-    <param name="rate" value="30"/>
-  </node>
 </launch>

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -35,6 +35,9 @@
     <arg name="paused" value="true"/>
     <arg name="gui" value="$(eval not arg('headless'))"/>
     <arg name="use_sim_time" value="true"/>
+    <!-- Remap both, arm and gripper joint states to default ROS topic joint_states -->
+    <remap from="franka_state_controller/joint_states" to="joint_states" />
+    <remap from="franka_gripper/joint_states" to="joint_states" />
   </include>
 
   <param name="robot_description"
@@ -76,10 +79,6 @@
   />
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-  <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-    <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
-    <param name="rate" value="30"/>
-  </node>
 
   <!-- Start only if cartesian_impedance_example_controller -->
   <node name="interactive_marker"

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -80,11 +80,6 @@
     <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
     <param name="rate" value="30"/>
   </node>
-  <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-    <rosparam param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-    <param name="rate" value="30"/>
-    <remap from="joint_states" to="joint_states_desired" />
-  </node>
 
   <!-- Start only if cartesian_impedance_example_controller -->
   <node name="interactive_marker"


### PR DESCRIPTION
Re-publishing `joint_states` via `joint_state_publisher` (a python app) is highly inefficient. 
IMO remapping would be the right way to go instead - as long nobody needs the published topics on the namespace 
`franka_state_controller` / `franka_gripper`. 

But, remapping has its drawbacks too:
- It breaks existing software relying on topics `franka_state_controller/joint_states` and/or `franka_gripper/joint_states`
- `joint_states` messages from arm and gripper are published both to the same topic, so we cannot easily distinguish them anymore (w/o looking at the message of course)
- The variable message format (7 vs. 2 joints) might confuse existing software, e.g. `rqt_plot`.

Note: This PR includes #191.