### PR TITLE
Define meaningful tool frame

### DIFF
--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -52,6 +52,13 @@
         </geometry>
       </collision>
     </link>
+    <!-- Define the hand_tcp frame -->
+    <link name="${ns}_hand_tcp" />
+    <joint name="${ns}_hand_tcp_joint" type="fixed">
+      <origin xyz="0 0 0.1034" rpy="0 0 0" />
+      <parent link="${ns}_hand" />
+      <child link="${ns}_hand_tcp" />
+    </joint>
     <link name="${ns}_leftfinger">
       <visual>
         <geometry>


### PR DESCRIPTION
When a hand is mounted, the `link8` frame is 45° rotated wrt. the hand.
Better define a `tool` frame that is nicely aligned with the hand, i.e.
x=normal, y=slide, z=approach, and nicely centered between the fingers.

| Before | After |
|-----------|--------|
| ![image](https://user-images.githubusercontent.com/5376030/140649827-d9bb9f35-a10c-467e-be71-8e88a1bd0d37.png) | ![image](https://user-images.githubusercontent.com/5376030/140649559-8227cf7c-6cff-4ffc-98d7-98575aa0df01.png) |