### PR TITLE
fix interactive marker initialization

### DIFF
--- a/franka_example_controllers/scripts/interactive_marker.py
+++ b/franka_example_controllers/scripts/interactive_marker.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     link_name = rospy.get_param("~link_name")
 
     # Get initial pose for the interactive marker
-    while not initial_pose_found and rospy.is_shutdown():
+    while not initial_pose_found and not rospy.is_shutdown():
         rospy.sleep(1)
     state_sub.unregister()
 


### PR DESCRIPTION
Wait until an initial pose is found unless rospy is in shutdown state.