### PR TITLE
feat(gazebo): add hand_tcp frame to gazebo robot description

### DIFF
--- a/franka_description/robots/panda_gazebo.xacro
+++ b/franka_description/robots/panda_gazebo.xacro
@@ -332,6 +332,14 @@
       </collision>
     </xacro:macro>
 
+    <!-- Define the hand_tcp frame -->
+    <link name="${ns}_hand_tcp" />
+    <joint name="${ns}_hand_tcp_joint" type="fixed">
+      <origin xyz="0 0 0.1034" rpy="0 0 0" />
+      <parent link="${ns}_hand" />
+      <child link="${ns}_hand_tcp" />
+    </joint>
+
     <link name="${ns}_leftfinger">
       <xacro:inertia-cylinder mass="15e-3" radius="0.01" h="0.04"/>
       <visual>


### PR DESCRIPTION
This pull request adds the `hand_tcp` frame that was defined in 97e73fabdeed69bc8deb8686f1973f0e03b6400f to the Gazebo robot description. This frame is positioned in the centre between and aligned with the fingers.

The code of this pull request is also contained in pull request #188 and is therefore not needed when this pull request is merged.