### PR TITLE
Use move in gripper_action when max_effort is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * `franka_control`: Configurable `arm_id` in launch & config files
   * `franka_description`: URDF now contains `$(arm_id)_linkN_sc` links containing the capsule collision modules used for self-collision avoidance (MoveIt).
   * `franka_gazebo`: Fix motion generator config respects `arm_id`
+  *  **BREAKING**: `gripper_action` goes now to the commanded gripper position when `max_effort` is zero
 
 ## 0.9.0 - 2022-03-29
 

--- a/franka_gazebo/include/franka_gazebo/franka_gripper_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_gripper_sim.h
@@ -136,5 +136,24 @@ class FrankaGripperSim
   void onMoveGoal(const franka_gripper::MoveGoalConstPtr& goal);
   void onGraspGoal(const franka_gripper::GraspGoalConstPtr& goal);
   void onGripperActionGoal(const control_msgs::GripperCommandGoalConstPtr& goal);
+
+  /**
+   * libfranka-like method to grasp an object with the gripper
+   * @param[in] width Size of the object to grasp. [m]
+   * @param[in] speed Closing speed. [m/s]
+   * @param[in] force Grasping force. [N]
+   * @param[in] epsilon Maximum tolerated deviation between the commanded width and the desired
+   * width
+   * @return True if the object could be grasped, false otherwise
+   */
+  bool grasp(double width, double speed, double force, const franka_gripper::GraspEpsilon& epsilon);
+
+  /**
+   * libfranka-like method to move the gripper to a certain position
+   * @param[in] width Intended opening width. [m]
+   * @param[in] speed Closing speed. [m/s]
+   * @return True if the command was successful, false otherwise.
+   */
+  bool move(double width, double speed);
 };
 }  // namespace franka_gazebo

--- a/franka_gazebo/src/franka_gripper_sim.cpp
+++ b/franka_gazebo/src/franka_gripper_sim.cpp
@@ -422,13 +422,15 @@ void FrankaGripperSim::onGripperActionGoal(const control_msgs::GripperCommandGoa
   double width_d = goal->command.position * 2.0;
 
   ROS_INFO_STREAM_NAMED("FrankaGripperSim", "New Gripper Command Action Goal received: "
-                                                << width_d << "m, " << goal->command.max_effort
-                                                << "N");
+                                                << goal->command.position << "m, "
+                                                << goal->command.max_effort << "N");
 
   if (width_d > kMaxFingerWidth || width_d < 0.0) {
     std::string error =
-        "Commanding out of range width! max_width = " + std::to_string(kMaxFingerWidth) +
-        " command = " + std::to_string(width_d);
+        "Commanding out of range position! max_position = " + std::to_string(kMaxFingerWidth / 2) +
+        ", commanded position = " + std::to_string(goal->command.position) +
+        ". Be aware that you command the position of"
+        " each finger which is half of the total opening width!";
     ROS_ERROR_STREAM_NAMED("FrankaGripperSim", error);
     result.reached_goal = static_cast<decltype(result.reached_goal)>(false);
     action_gc_->setAborted(result, error);

--- a/franka_gripper/src/franka_gripper.cpp
+++ b/franka_gripper/src/franka_gripper.cpp
@@ -48,7 +48,8 @@ void gripperCommandExecuteCallback(
     if (std::abs(target_width - state.width) < kSamePositionThreshold) {
       return true;
     }
-    if (target_width >= state.width) {
+    constexpr double kMinimumGraspForce = 1e-4;
+    if (std::abs(goal->command.max_effort) < kMinimumGraspForce or target_width >= state.width) {
       return gripper.move(target_width, default_speed);
     }
     return gripper.grasp(target_width, default_speed, goal->command.max_effort, grasp_epsilon.inner,

--- a/franka_gripper/src/franka_gripper.cpp
+++ b/franka_gripper/src/franka_gripper.cpp
@@ -40,8 +40,12 @@ void gripperCommandExecuteCallback(
 
     franka::GripperState state = gripper.readOnce();
     if (target_width > state.max_width || target_width < 0.0) {
-      ROS_ERROR_STREAM("GripperServer: Commanding out of range width! max_width = "
-                       << state.max_width << " command = " << target_width);
+      std::string error = "Commanding out of range position! max_position = " +
+                          std::to_string(state.max_width / 2) +
+                          ", commanded position = " + std::to_string(goal->command.position) +
+                          ". Be aware that you command the position of"
+                          " each finger which is half of the total opening width!";
+      ROS_ERROR_STREAM("GripperServer: " << error);
       return false;
     }
     constexpr double kSamePositionThreshold = 1e-4;


### PR DESCRIPTION
This PR implements the [my suggested workaround ](https://github.com/frankaemika/franka_ros/pull/173#issuecomment-964994857) from #173.

This PR solves #172. 

Now the gripper_action can close the gripper to a smaller width when max_effort is 0. However, since this is a breaking change we want to wait until the following issue is resolved in moveit (@rickstaa):

- [x]   [#2956 MoveIt: Make max_effort settable in the MoveIt Simple Controller Manager](https://github.com/ros-planning/moveit/issues/2956) 