### PR TITLE
feat(franka_gazebo): add physics engine launch argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_description`: `<xacro:franka_robot/>` macro now supports to customize the `parent` frame and its `xyz` + `rpy` offset
   * `franka_hw`: Fix the bug where the previous controller is still running after switching the controller. ([#326](https://github.com/frankaemika/franka_ros/issues/326))
   * `franka_gazebo`: Add `set_franka_model_configuration` service.
+  * `franka_gazebo`: Add Gazebo simulation physics engine command line argument
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -6,6 +6,7 @@
   <arg name="paused"      default="false" doc="Should the simulation directly be stopped at 0s?" />
   <arg name="world"       default="worlds/empty.world" doc="Filename to a SDF World for gazebo to use" />
   <arg name="rviz"        default="false" doc="Should RVIz be launched?" />
+  <arg name="physics"     default="ode"   doc="The physics engine used by gazebo"/> <!--Phyics engines: ode|dart-->
 
   <!-- Robot Customization -->
   <arg name="arm_id"      default="panda" doc="Name of the robot to spawn" />
@@ -38,6 +39,7 @@
     <arg name="paused" value="$(arg paused)" />
     <arg name="world" value="$(arg world)" />
     <arg name="rviz" value="$(arg rviz)" />
+    <arg name="physics" value="$(arg physics)" />
 
     <arg name="robot" value="panda" />
     <arg name="arm_id" value="$(arg arm_id)" />

--- a/franka_gazebo/launch/robot.launch
+++ b/franka_gazebo/launch/robot.launch
@@ -7,6 +7,7 @@
   <arg name="paused"      default="false" doc="Should the simulation directly be stopped at 0s?" />
   <arg name="world"       default="worlds/empty.world" doc="Filename to a SDF World for gazebo to use" />
   <arg name="rviz"        default="false" doc="Should RVIz be launched?" />
+  <arg name="physics"     default="ode"   doc="The physics engine used by gazebo"/> <!--Phyics engines: ode|dart-->
 
   <!-- Robot Customization -->
   <arg name="robot"                       doc="Which robot to spawn (one of {panda,fr3})" />
@@ -40,6 +41,7 @@
     <arg name="paused" value="true"/>
     <arg name="gui" value="$(eval not arg('headless'))"/>
     <arg name="use_sim_time" value="true"/>
+    <arg name="physics" value="$(arg physics)"/>
   </include>
 
   <param name="robot_description"

--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -82,6 +82,17 @@ bool FrankaHWSim::initSim(const std::string& robot_namespace,
 
   ROS_INFO_STREAM_NAMED("franka_hw_sim", "Using physics type " << physics->GetType());
 
+  // Print information about the used physics engine
+  std::vector<std::string> supported_engines{"ode", "dart"};
+  std::string physics_engine = physics->GetType();
+  ROS_INFO_STREAM_NAMED("franka_hw_sim", "Using physics type " << physics->GetType());
+  if (std::find(supported_engines.begin(), supported_engines.end(), physics_engine) ==
+      supported_engines.end()) {
+    ROS_ERROR_STREAM_NAMED("franka_hw_sim",
+                           "The Panda Gazebo model does not yet officially support the '" +
+                               physics_engine + "' physics engine.");
+  }
+
   // Retrieve initial gravity vector from Gazebo
   // NOTE: Can be overwritten by the user via the 'gravity_vector' ROS parameter.
   auto gravity = physics->World()->Gravity();


### PR DESCRIPTION
A simple pull request gives users the ability to change the physics engine. I used DART as the default physics engine since it appears to be the most stable (https://github.com/frankaemika/franka_ros/issues/160#issuecomment-989173918). The only downside of using this engine compared to the ODE engine is that the `get_physics_properties` service call does not yet support the physics engine [bullet].

Please note that the BULLET and SIMBODY physics engines do not work with the current model (see https://github.com/frankaemika/franka_ros/issues/160#issuecomment-989173918). dcc5eb0476d05300b6a2b02d407581f3f1f2a8f9 adds a warning to communicate this to the user.