### PR TITLE
Adds optional joint to connect the panda in panda_gazebo.xacro, similar to panda_arm.xacro

### DIFF
--- a/franka_description/robots/panda_gazebo.xacro
+++ b/franka_description/robots/panda_gazebo.xacro
@@ -11,7 +11,14 @@
   <!-- || Paolo Robuffo Giordano, Alessandro de Luca                || -->
   <!-- =============================================================== -->
 
-  <xacro:macro name="panda_arm" params="arm_id:='panda'">
+  <xacro:macro name="panda_arm" params="arm_id:='panda' connected_to=''">
+    <xacro:unless value="${not connected_to}">
+      <joint name="${arm_id}_joint_${connected_to}" type="fixed">
+        <parent link="${connected_to}"/>
+        <child link="${arm_id}_link0"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+      </joint>
+    </xacro:unless>
     <link name="${arm_id}_link0">
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>


### PR DESCRIPTION
Hi,

We're currently working on integrating the panda arm on a mobile base, and I noticed there is a difference between panda_gazebo.xacro and panda_arm.xacro. The parameter `connected_to` is missing which is required to connect the panda in gazebo to another link.

edit: after looking at the issues I saw #168 is exactly this