### PR TITLE
feat(franka_gazebo): add 'log_level' parameter to 'FrankaGripperSim' gazebo plugin

### DIFF
--- a/franka_gazebo/include/franka_gazebo/franka_gripper_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_gripper_sim.h
@@ -16,6 +16,7 @@
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
 #include <realtime_tools/realtime_publisher.h>
+#include <ros/console.h>
 #include <ros/time.h>
 #include <sensor_msgs/JointState.h>
 
@@ -37,6 +38,9 @@ const double kGraspRestingThreshold = 0.003;
 
 /// How many times the speed has to drop below resting threshold before the grasping will be checked
 const int kGraspConsecutiveSamples = 10;
+
+/// The log level used by the 'franka_gripper_sim' Gazebo plugin
+const std::string kLogLevel = "Info";
 
 /**
  * Simulate the franka_gripper_node.
@@ -104,6 +108,7 @@ class FrankaGripperSim
   double tolerance_move_;            ///< [m] inner + outer position tolerances used during grasp
   double tolerance_gripper_action_;  ///< [m] inner + outer position tolerances used during gripper
                                      ///< action
+  std::string log_level_;            /// The log level that is used
 
   std::unique_ptr<actionlib::SimpleActionServer<franka_gripper::StopAction>> action_stop_;
   std::unique_ptr<actionlib::SimpleActionServer<franka_gripper::HomingAction>> action_homing_;

--- a/franka_gazebo/src/franka_gripper_sim.cpp
+++ b/franka_gazebo/src/franka_gripper_sim.cpp
@@ -3,6 +3,7 @@
 
 #include <franka_gazebo/franka_gripper_sim.h>
 #include <pluginlib/class_list_macros.h>
+#include <boost/assign.hpp>
 
 namespace franka_gazebo {
 
@@ -31,6 +32,20 @@ bool FrankaGripperSim::init(hardware_interface::EffortJointInterface* hw, ros::N
   nh.param<double>("gripper_action/speed", this->speed_default_, kDefaultGripperActionSpeed);
   nh.param<double>("grasp/resting_threshold", this->speed_threshold_, kGraspRestingThreshold);
   nh.param<int>("grasp/consecutive_samples", this->speed_samples_, kGraspConsecutiveSamples);
+  nh.param<std::string>("log_level", this->log_level_, kLogLevel);
+  this->log_level_[0] = toupper(this->log_level_[0]);
+
+  // Set the plugin log level
+  std::map<std::string, ros::console::levels::Level> level_map =
+      boost::assign::map_list_of("Debug", ros::console::levels::Debug)(
+          "Info", ros::console::levels::Info)("Warn", ros::console::levels::Warn)(
+          "Error", ros::console::levels::Error)("Fatal", ros::console::levels::Fatal);
+  const ros::console::levels::Level kLogLevelEnum =
+      (level_map.find(this->log_level_) != level_map.end()) ? level_map[this->log_level_]
+                                                            : ros::console::levels::Info;
+  if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, kLogLevelEnum)) {
+    ros::console::notifyLoggerLevelsChanged();
+  }
 
   try {
     this->finger1_ = hw->getHandle(finger1);


### PR DESCRIPTION
This pull request adds the 'franka_gripper/log_level' parameter to the 'FrankaGripperSim' Gazebo Plugin. This parameter allows users to get rid of the excessive logging of received action server commands. I need this in my fork since the logging slows down my training script. Another solution would be to change the `ROS_INFO_STREAM_NAMED` console logs to `ROS_DEBUG_STREAM_NAMED` (see #214).