### PR TITLE
fix(franka_gazebo): fix `tau_ext` internal controller bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_description`: `<xacro:franka_robot/>` macro now supports to customize the `parent` frame and its `xyz` + `rpy` offset
   * `franka_hw`: Fix the bug where the previous controller is still running after switching the controller. ([#326](https://github.com/frankaemika/franka_ros/issues/326))
   * `franka_gazebo`: Add `set_franka_model_configuration` service.
+  * `franka_gazebo`: Fix external torque calculation by accounting for internal joint limits
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_gazebo/include/franka_gazebo/joint.h
+++ b/franka_gazebo/include/franka_gazebo/joint.h
@@ -55,6 +55,10 @@ struct Joint {
   /// \f$Nm\f$ without gravity
   double command = 0;
 
+  /// The clamped applied command from a controller acting on this joint either in \f$N\f$ or
+  /// \f$Nm\f$ without gravity. Set to zero when joint command is saturated due to joint limits.
+  double clamped_command = 0;
+
   /// The current desired position that is used for the PID controller when the joints control
   /// method is "POSITION". When the control method is not "POSITION", this value will only be
   /// updated once at the start of the controller and stay the same until a new controller is

--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -679,7 +679,8 @@ void FrankaHWSim::updateRobotState(ros::Time time) {
     }
 
     if (this->robot_initialized_) {
-      double tau_ext = joint->effort - joint->command + joint->gravity;
+      // NOTE: Use clamped_command to account for internal joint saturation.
+      double tau_ext = joint->effort - joint->clamped_command + joint->gravity;
 
       // Exponential moving average filter from tau_ext -> tau_ext_hat_filtered
       this->robot_state_.tau_ext_hat_filtered[i] =


### PR DESCRIPTION
This PR ensures that internal controller forces are not used in the external torque calculations when a joint is within its
joint limits. This needs to be done since, in that case, the joint boundaries already compensate for external torques (see https://github.com/frankaemika/franka_ros/issues/364). Feel free to change this pull request however you like, as there are multiple ways to solve this problem.