### PR TITLE
Avoid republishing joints

### DIFF
--- a/franka_visualization/launch/franka_visualization.launch
+++ b/franka_visualization/launch/franka_visualization.launch
@@ -11,17 +11,14 @@
     <rosparam command="load" file="$(find franka_visualization)/config/robot_settings.yaml" />
     <param name="robot_ip" value="$(arg robot_ip)" />
     <param name="publish_rate" value="$(arg publish_rate)" />
+    <remap from="~/joint_states" to="joint_states" />
   </node>
 
   <node name="gripper_joint_state_publisher" pkg="franka_visualization" type="gripper_joint_state_publisher" output="screen" if="$(arg load_gripper)">
     <rosparam command="load" file="$(find franka_visualization)/config/gripper_settings.yaml" />
     <param name="robot_ip" value="$(arg robot_ip)" />
     <param name="publish_rate" value="$(arg publish_rate)" />
-  </node>
-
-  <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <param name="rate" value="$(arg publish_rate)" />
-    <rosparam param="source_list">[robot_joint_state_publisher/joint_states, gripper_joint_state_publisher/joint_states]</rosparam>
+    <remap from="~/joint_states" to="joint_states" />
   </node>
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />


### PR DESCRIPTION
As already stated in #191, republishing joints via the python `joint_state_publisher` is highly inefficient.
But it is also _misleading_: In my case, I didn't receive any messages from `franka_visualization/robot_joint_state_publisher` and `franka_visualization/gripper_joint_state_publisher`. Nevertheless, the `joint_state_publisher` publishes `/joint_states` regularly (using default, zero-centered values), giving the wrong impression that the connection to the robot is correctly established!

Alternatively to remapping as suggested in this PR, `robot_joint_state_publisher` and `gripper_joint_state_publisher` could directly publish to `/joint_states`, of course.