### PR TITLE
fix: fix dual panda motion generator PID gains bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * `franka_example_controllers`: Extend the `teleop_joint_pd_example_controller` with joint walls to actively avoid position or velocity limit violations.
   * `franka_control`: Configurable `arm_id` in launch & config files
   * `franka_description`: URDF now contains `$(arm_id)_linkN_sc` links containing the capsule collision modules used for self-collision avoidance (MoveIt).
+  * `franka_gazebo`: Fix motion generator config respects `arm_id`
 
 ## 0.9.0 - 2022-03-29
 

--- a/franka_gazebo/config/franka_hw_sim.yaml
+++ b/franka_gazebo/config/franka_hw_sim.yaml
@@ -16,19 +16,19 @@ franka_gripper:
 motion_generators:
   position:
     gains:
-      panda_joint1: { p: 600, d: 30, i: 0 }
-      panda_joint2: { p: 600, d: 30, i: 0 }
-      panda_joint3: { p: 600, d: 30, i: 0 }
-      panda_joint4: { p: 600, d: 30, i: 0 }
-      panda_joint5: { p: 250, d: 10, i: 0 }
-      panda_joint6: { p: 150, d: 10, i: 0 }
-      panda_joint7: { p:  50, d:  5, i: 0 }
+      $(arg arm_id)_joint1: { p: 600, d: 30, i: 0 }
+      $(arg arm_id)_joint2: { p: 600, d: 30, i: 0 }
+      $(arg arm_id)_joint3: { p: 600, d: 30, i: 0 }
+      $(arg arm_id)_joint4: { p: 600, d: 30, i: 0 }
+      $(arg arm_id)_joint5: { p: 250, d: 10, i: 0 }
+      $(arg arm_id)_joint6: { p: 150, d: 10, i: 0 }
+      $(arg arm_id)_joint7: { p:  50, d:  5, i: 0 }
   velocity:
     gains:
-      panda_joint1: { p: 30, d: 0, i: 0 }
-      panda_joint2: { p: 30, d: 0, i: 0 }
-      panda_joint3: { p: 30, d: 0, i: 0 }
-      panda_joint4: { p: 30, d: 0, i: 0 }
-      panda_joint5: { p: 10, d: 0, i: 0 }
-      panda_joint6: { p: 10, d: 0, i: 0 }
-      panda_joint7: { p:  5, d:  0, i: 0 }
+      $(arg arm_id)_joint1: { p: 30, d: 0, i: 0 }
+      $(arg arm_id)_joint2: { p: 30, d: 0, i: 0 }
+      $(arg arm_id)_joint3: { p: 30, d: 0, i: 0 }
+      $(arg arm_id)_joint4: { p: 30, d: 0, i: 0 }
+      $(arg arm_id)_joint5: { p: 10, d: 0, i: 0 }
+      $(arg arm_id)_joint6: { p: 10, d: 0, i: 0 }
+      $(arg arm_id)_joint7: { p:  5, d:  0, i: 0 }


### PR DESCRIPTION
@marcbone This pull request makes sure that the 'arm_id' is taken into account when the motion generator PID gains are loaded onto the ROS parameter server. I noticed that we forgot to include the dual panda setup described by @rhaschke in https://github.com/frankaemika/franka_ros/pull/196#issue-1048452563 when we merged 2514ae1990d51ca808e6c49d22d24ae7a99db532.

## How to reproduce.

1. Build the franka_ros package.
2. Source the franka_ros package.
3. Try to spawn two panda robots using the following commands in different terminals:

```bash
# Start single Gazebo instance (with empty world):
roslaunch gazebo_ros empty_world.launch world_name:=worlds/empty.world use_sim_time:=true paused:=true
# Spawn robot panda1 into namespace left
ROS_NAMESPACE=left roslaunch franka_gazebo panda.launch gazebo:=false arm_id:=panda1 y:=0 paused:=true
# Spawn robot panda2 into namespace right
ROS_NAMESPACE=right roslaunch franka_gazebo panda.launch gazebo:=false arm_id:=panda2 y:=1 paused:=false
```

4. Be greeted by the following errors:

```bash
[/gazebo] [ERROR] [WallTime: 1647879761.328384282]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint1
[/gazebo] [ INFO] [WallTime: 1647879761.328639773]: Found transmission interface of joint 'panda1_joint2': hardware_interface/PositionJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.328962427]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint2
[/gazebo] [ INFO] [WallTime: 1647879761.329020354]: Found transmission interface of joint 'panda1_joint3': hardware_interface/PositionJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.329330334]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint3
[/gazebo] [ INFO] [WallTime: 1647879761.329358906]: Found transmission interface of joint 'panda1_joint4': hardware_interface/PositionJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.329677448]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint4
[/gazebo] [ INFO] [WallTime: 1647879761.329712635]: Found transmission interface of joint 'panda1_joint5': hardware_interface/PositionJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.329995357]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint5
[/gazebo] [ INFO] [WallTime: 1647879761.330029905]: Found transmission interface of joint 'panda1_joint6': hardware_interface/PositionJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.330305189]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint6
[/gazebo] [ INFO] [WallTime: 1647879761.330339015]: Found transmission interface of joint 'panda1_joint7': hardware_interface/PositionJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.330564114]: No p gain specified for pid.  Namespace: /left/motion_generators/position/gains/panda1_joint7
[/gazebo] [ INFO] [WallTime: 1647879761.330595433]: Found transmission interface of joint 'panda1_joint1': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.330834847]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint1
[/gazebo] [ INFO] [WallTime: 1647879761.330882767]: Found transmission interface of joint 'panda1_joint2': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.331115950]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint2
[/gazebo] [ INFO] [WallTime: 1647879761.331144046]: Found transmission interface of joint 'panda1_joint3': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.331350666]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint3
[/gazebo] [ INFO] [WallTime: 1647879761.331378690]: Found transmission interface of joint 'panda1_joint4': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.331629974]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint4
[/gazebo] [ INFO] [WallTime: 1647879761.331657665]: Found transmission interface of joint 'panda1_joint5': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.331887226]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint5
[/gazebo] [ INFO] [WallTime: 1647879761.331916082]: Found transmission interface of joint 'panda1_joint6': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.332112102]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint6
[/gazebo] [ INFO] [WallTime: 1647879761.332139902]: Found transmission interface of joint 'panda1_joint7': hardware_interface/VelocityJointInterface
[/gazebo] [ERROR] [WallTime: 1647879761.332333453]: No p gain specified for pid.  Namespace: /left/motion_generators/velocity/gains/panda1_joint7
```
