### PR TITLE
Added a namespace getter to the roslaunch Node

### DIFF
--- a/franka_gazebo/scripts/delayed_controller_spawner.py
+++ b/franka_gazebo/scripts/delayed_controller_spawner.py
@@ -27,7 +27,7 @@ def main():
             break
 
     rospy.loginfo('Waking up. Spawning controller...')
-    node = roslaunch.core.Node(package, node_type, name=node_type, args=args)
+    node = roslaunch.core.Node(package, node_type, name=node_type, namespace=rospy.get_namespace(), args=args)
     launch = roslaunch.scriptapi.ROSLaunch()
     launch.start()
     launch.launch(node)


### PR DESCRIPTION
This fixes a bug where the robot could not find its cartesian_impedance_example_controller if launched from a namespace that is not the default one.

How to reproduce:
Ubuntu 18.04
ros melodic
franka_ros Version 0.9.0

Run this launchfile or something similar with a robot in a namespace:
````
<?xml version="1.0"?>
<launch>

  <include file="$(find gazebo_ros)/launch/empty_world.launch" >
    <!-- Start paused, simulation will be started, when Pandas were loaded -->
    <arg name="paused" value="true"/>
    <arg name="use_sim_time" value="true"/>
  </include>

  <group ns="namespace_testing">
    <include file="$(find franka_gazebo)/launch/panda.launch">
      <arg name="arm_id"     value="panda_1" />
      <arg name="controller" value="cartesian_impedance_example_controller" />
      <arg name="rviz"       value="false" />
      <arg name="gazebo"     value="false" />
      <arg name="paused"     value="false" />
    </include>
  </group>

</launch>
````

You will observe that the robot will sway for some time as the controller does not work. After roughly 25 seconds you will get the following warning:

> [WARN] [1651669475.566877, 27.666000]: Controller Spawner couldn't find the expected controller_manager ROS interface.

I did not test this with other controllers or multiple robots but I assume they also have this problem.
