### PR TITLE
load interial.yaml with relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * `franka_control`: Configurable `arm_id` in launch & config files
   * `franka_description`: URDF now contains `$(arm_id)_linkN_sc` links containing the capsule collision modules used for self-collision avoidance (MoveIt).
   * `franka_description`: Unit test suite for URDFs
+  * `franka_description`: Make `util.xacro` be includable from other packages
   * `franka_gazebo`: Fix motion generator config respects `arm_id`
   *  **BREAKING**: `gripper_action` goes now to the commanded gripper position when `max_effort` is zero
 

--- a/franka_description/robots/utils.xacro
+++ b/franka_description/robots/utils.xacro
@@ -2,8 +2,8 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Load interial properties. Property is implicitly passed to macros. -->
-  <xacro:property name="interial_config" value="$(find franka_description)/robots/inertial.yaml"/>
-  <xacro:property name="inertial" value="${xacro.load_yaml(interial_config)}"/>
+  <xacro:property name="inertial_config" value="$(find franka_description)/robots/inertial.yaml"/>
+  <xacro:property name="inertial" value="${xacro.load_yaml(inertial_config)}"/>
 
   <!-- ============================================================== -->
   <!-- Macro to add an <interial> tag based on yaml-load properties   -->

--- a/franka_description/robots/utils.xacro
+++ b/franka_description/robots/utils.xacro
@@ -2,7 +2,8 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Load interial properties. Property is implicitly passed to macros. -->
-  <xacro:property name="inertial" value="${xacro.load_yaml('inertial.yaml')}" />
+  <xacro:property name="interial_config" value="$(find franka_description)/robots/inertial.yaml"/>
+  <xacro:property name="inertial" value="${xacro.load_yaml(interial_config)}"/>
 
   <!-- ============================================================== -->
   <!-- Macro to add an <interial> tag based on yaml-load properties   -->


### PR DESCRIPTION
The change allows the `interial.yaml` file to be loaded with a relative path to the `franka_description` package. 

When preparing a custom xacro file for a dual Franka robot arm, I faced the problem that the `inertial.yaml` can not be loaded/found. Loading the file with a relative path solved this problem. Without the relative path, users must copy the `inertial.yaml` file to the same directory where their custom xacro includes the `util.xacro` file.

Thank you for including the interia information in the model! 