### PR TITLE
Fix(franka_example_controllers): Fix dynamic reconfigure node name for cartesian_impedance_example_con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * `franka_example_controllers`: Extend the `teleop_joint_pd_example_controller` with markers indicating leader and follower roles + consistently use leader and follower as robot names in the example. 
   * `franka_example_controllers`: Extend the `teleop_joint_pd_example_controller` with a finite state machine that aligns the follower robot before starting to track the leader.
   * `franka_example_controllers`: Extend the `teleop_joint_pd_example_controller` with joint walls to actively avoid position or velocity limit violations.
+  * `franka_example_controllers`: Fix namespacing of dynamic reconfigure node of cartesian impedance example controller
   * `franka_control`: Configurable `arm_id` in launch & config files
   * `franka_description`: URDF now contains `$(arm_id)_linkN_sc` links containing the capsule collision modules used for self-collision avoidance (MoveIt).
   * `franka_description`: Unit test suite for URDFs

--- a/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
@@ -85,7 +85,7 @@ bool CartesianImpedanceExampleController::init(hardware_interface::RobotHW* robo
   }
 
   dynamic_reconfigure_compliance_param_node_ =
-      ros::NodeHandle(node_handle.getNamespace() + "dynamic_reconfigure_compliance_param_node");
+      ros::NodeHandle(node_handle.getNamespace() + "/dynamic_reconfigure_compliance_param_node");
 
   dynamic_server_compliance_param_ = std::make_unique<
       dynamic_reconfigure::Server<franka_example_controllers::compliance_paramConfig>>(


### PR DESCRIPTION
Add a missing / to the node name so that the node name is:

`/cartesian_impedance_example_controller/dynamic_reconfigure_compliance_param_node/`

instead of:

`/cartesian_impedance_example_controllerdynamic_reconfigure_compliance_param_node/`

