### PR TITLE
remove panda_moveit_config from metapackage deps

### DIFF
--- a/franka_ros/package.xml
+++ b/franka_ros/package.xml
@@ -21,7 +21,6 @@
   <exec_depend>franka_msgs</exec_depend>
   <exec_depend>franka_visualization</exec_depend>
   <exec_depend>franka_gazebo</exec_depend>
-  <exec_depend>panda_moveit_config</exec_depend>
 
   <export>
     <metapackage />


### PR DESCRIPTION
As part of https://github.com/frankaemika/franka_ros/commit/7f02b72e078654b28a799601101537c1e02e70fa panda_moveit_config should be removed from the metapackage