### PR TITLE
Add dual arm impedance controller for different target

### DIFF
--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -33,9 +33,13 @@ endif()
 
 add_message_files(FILES
   JointTorqueComparison.msg
+  ArmsTargetPose.msg
 )
 
-generate_messages()
+generate_messages(DEPENDENCIES
+  std_msgs
+  geometry_msgs
+)
 
 generate_dynamic_reconfigure_options(
   cfg/compliance_param.cfg
@@ -79,6 +83,7 @@ add_library(franka_example_controllers
   src/cartesian_impedance_example_controller.cpp
   src/force_example_controller.cpp
   src/dual_arm_cartesian_impedance_example_controller.cpp
+  src/dual_arm_cartesian_pose_controller.cpp
   src/teleop_joint_pd_example_controller.cpp
   src/joint_wall.cpp
 )

--- a/franka_example_controllers/config/franka_example_controllers.yaml
+++ b/franka_example_controllers/config/franka_example_controllers.yaml
@@ -116,6 +116,29 @@ dual_arm_cartesian_impedance_example_controller:
             - panda_2_joint6
             - panda_2_joint7
 
+dual_arm_cartesian_pose_controller:
+    type: franka_example_controllers/DualArmCartesianPoseController
+    right:
+        arm_id: panda_1
+        joint_names:
+            - panda_1_joint1
+            - panda_1_joint2
+            - panda_1_joint3
+            - panda_1_joint4
+            - panda_1_joint5
+            - panda_1_joint6
+            - panda_1_joint7
+    left:
+        arm_id: panda_2
+        joint_names:
+            - panda_2_joint1
+            - panda_2_joint2
+            - panda_2_joint3
+            - panda_2_joint4
+            - panda_2_joint5
+            - panda_2_joint6
+            - panda_2_joint7
+
 teleop_joint_pd_example_controller:
    type: franka_example_controllers/TeleopJointPDExampleController
    leader:

--- a/franka_example_controllers/franka_example_controllers_plugin.xml
+++ b/franka_example_controllers/franka_example_controllers_plugin.xml
@@ -54,4 +54,9 @@
           A PD controller that tracks position and velocity of the leader arm and applies it to the follower arm. It also applies force-feedback to the leader arm.
       </description>
   </class>
+  <class name="franka_example_controllers/DualArmCartesianPoseController" type="franka_example_controllers::DualArmCartesianPoseController" base_class_type="controller_interface::ControllerBase">
+      <description>
+          A dual arm impedance controller with different targets. Commands are sent via pose.
+      </description>
+  </class>
 </library>

--- a/franka_example_controllers/include/franka_example_controllers/dual_arm_cartesian_pose_controller.h
+++ b/franka_example_controllers/include/franka_example_controllers/dual_arm_cartesian_pose_controller.h
@@ -1,0 +1,187 @@
+// Copyright (c) 2019 Franka Emika GmbH
+// Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <controller_interface/multi_interface_controller.h>
+#include <dynamic_reconfigure/server.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <franka_example_controllers/ArmsTargetPose.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/robot_hw.h>
+#include <realtime_tools/realtime_publisher.h>
+#include <ros/node_handle.h>
+#include <ros/time.h>
+#include <Eigen/Dense>
+
+#include <franka_example_controllers/dual_arm_compliance_paramConfig.h>
+#include <franka_hw/franka_model_interface.h>
+#include <franka_hw/franka_state_interface.h>
+#include <franka_hw/trigger_rate.h>
+
+namespace franka_example_controllers {
+
+/**
+ * This container holds all data and parameters used to control one panda arm with a Cartesian
+ * impedance control law tracking a desired target pose.
+ */
+struct FrankaDataContainer {
+  std::unique_ptr<franka_hw::FrankaStateHandle>
+      state_handle_;  ///< To read to complete robot state.
+  std::unique_ptr<franka_hw::FrankaModelHandle>
+      model_handle_;  ///< To have access to e.g. jacobians.
+  std::vector<hardware_interface::JointHandle> joint_handles_;  ///< To command joint torques.
+  double filter_params_{0.005};       ///< [-] PT1-Filter constant to smooth target values set
+                                      ///< by dynamic reconfigure servers (stiffness/damping)
+                                      ///< or interactive markers for the target poses.
+  double nullspace_stiffness_{20.0};  ///< [Nm/rad] To track the initial joint configuration in
+                                      ///< the nullspace of the Cartesian motion.
+  double nullspace_stiffness_target_{20.0};  ///< [Nm/rad] Unfiltered raw value.
+  const double delta_tau_max_{1.0};          ///< [Nm/ms] Maximum difference in joint-torque per
+                                             ///< timestep. Used to saturated torque rates to ensure
+                                             ///< feasible commands.
+  Eigen::Matrix<double, 6, 6> cartesian_stiffness_;         ///< To track the target pose.
+  Eigen::Matrix<double, 6, 6> cartesian_stiffness_target_;  ///< Unfiltered raw value.
+  Eigen::Matrix<double, 6, 6> cartesian_damping_;           ///< To damp cartesian motions.
+  Eigen::Matrix<double, 6, 6> cartesian_damping_target_;    ///< Unfiltered raw value.
+  Eigen::Matrix<double, 7, 1> q_d_nullspace_;               ///< Target joint pose for nullspace
+                                                            ///< motion. For now we track the
+                                                            ///< initial joint pose.
+  Eigen::Vector3d position_d_;               ///< Target position of the end effector.
+  Eigen::Quaterniond orientation_d_;         ///< Target orientation of the end effector.
+  Eigen::Vector3d position_d_target_;        ///< Unfiltered raw value.
+  Eigen::Quaterniond orientation_d_target_;  ///< Unfiltered raw value.
+};
+
+/**
+ * Controller class for ros_control that renders two decoupled Cartesian impedances for the
+ * tracking of two target poses for the two endeffectors. The controller can be reparameterized at
+ * runtime via dynamic reconfigure servers.
+ */
+class DualArmCartesianPoseController
+    : public controller_interface::MultiInterfaceController<
+          franka_hw::FrankaModelInterface,
+          hardware_interface::EffortJointInterface,
+          franka_hw::FrankaStateInterface> {
+ public:
+  /**
+   * Initializes the controller class to be ready to run.
+   *
+   * @param[in] robot_hw Pointer to a RobotHW class to get interfaces and resource handles.
+   * @param[in] node_handle Nodehandle that allows getting parameterizations from the server and
+   * starting subscribers.
+   * @return True if the controller was initialized successfully, false otherwise.
+   */
+  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& node_handle) override;
+
+  /**
+   * Prepares the controller for the real-time execution. This method is executed once every time
+   * the controller is started and runs in real-time.
+   */
+  void starting(const ros::Time&) override;
+
+  /**
+   * Computes the control-law and commands the resulting joint torques to the robot.
+   *
+   * @param[in] period The control period (here 0.001s).
+   */
+  void update(const ros::Time&, const ros::Duration& period) override;
+
+ private:
+  std::map<std::string, FrankaDataContainer>
+      arms_data_;             ///< Holds all relevant data for both arms.
+  std::string left_arm_id_;   ///< Name of the left arm, retrieved from the parameter server.
+  std::string right_arm_id_;  ///< Name of the right arm, retrieved from the parameter server.
+
+  ///< Transformation between base frames of the robots.
+  Eigen::Affine3d Ol_T_Or_;  // NOLINT (readability-identifier-naming)
+  ///< Target transformation between the two endeffectors.
+  Eigen::Affine3d EEr_T_EEl_;  // NOLINT (readability-identifier-naming)
+  ///< Transformation from the centering frame to the left end effector.
+  Eigen::Affine3d EEl_T_C_{};
+
+  ///< Publisher for the centering tracking frame of the coordinated motion.
+  realtime_tools::RealtimePublisher<geometry_msgs::PoseStamped> right_frame_pub_;
+  realtime_tools::RealtimePublisher<geometry_msgs::PoseStamped> left_frame_pub_;
+  ///< Rate to trigger publishing the current pose of the centering frame.
+  franka_hw::TriggerRate publish_rate_;
+
+  /**
+   * Saturates torque commands to ensure feasibility.
+   *
+   * @param[in] arm_data The data container of the arm.
+   * @param[in] tau_d_calculated The raw command according to the control law.
+   * @param[in] tau_J_d The current desired torque, read from the robot state.
+   * @return The saturated torque command for the 7 joints of one arm.
+   */
+  Eigen::Matrix<double, 7, 1> saturateTorqueRate(
+      const FrankaDataContainer& arm_data,
+      const Eigen::Matrix<double, 7, 1>& tau_d_calculated,
+      const Eigen::Matrix<double, 7, 1>& tau_J_d);  // NOLINT (readability-identifier-naming)
+
+  /**
+   * Initializes a single Panda robot arm.
+   *
+   * @param[in] robot_hw A pointer the RobotHW class for getting interfaces and resource handles.
+   * @param[in] arm_id The name of the panda arm.
+   * @param[in] joint_names The names of all joints of the panda.
+   * @return True if successful, false otherwise.
+   */
+  bool initArm(hardware_interface::RobotHW* robot_hw,
+               const std::string& arm_id,
+               const std::vector<std::string>& joint_names);
+
+  /**
+   * Computes the decoupled controller update for a single arm.
+   *
+   * @param[in] arm_data The data container of the arm to control.
+   */
+  void updateArm(FrankaDataContainer& arm_data);
+
+  /**
+   * Prepares all internal states to be ready to run the real-time control for one arm.
+   *
+   * @param[in] arm_data The data container of the arm to prepare for the control loop.
+   */
+  void startingArm(FrankaDataContainer& arm_data);
+
+  ///< Dynamic reconfigure server
+  std::unique_ptr<dynamic_reconfigure::Server<
+      franka_combined_example_controllers::dual_arm_compliance_paramConfig>>
+      dynamic_server_compliance_param_;
+
+  ///< Nodehandle for the dynamic reconfigure namespace
+  ros::NodeHandle dynamic_reconfigure_compliance_param_node_;
+
+  /**
+   * Callback for updates on the parameterization of the controller in terms of stiffnesses.
+   *
+   * @param[in] config Data container for configuration updates.
+   */
+  void complianceParamCallback(
+      franka_combined_example_controllers::dual_arm_compliance_paramConfig& config,
+      uint32_t /*level*/);
+
+  ///< Target pose subscriber
+  ros::Subscriber sub_target_pose_left_;
+  ros::Subscriber sub_arms_target_pose_;
+
+  /**
+   * Callback method that handles updates of the target poses.
+   *
+   * @param[in] msg New target pose.
+   */
+  void targetPoseCallback(const geometry_msgs::PoseStamped::ConstPtr& msg);
+
+  /**
+   * Publishes a Pose Stamped for visualization of the current centering pose.
+   */
+  void targetArmsPoseCallback(const franka_example_controllers::ArmsTargetPose::ConstPtr& msg);
+  void publishCurrentPose();
+};
+
+}  // namespace franka_example_controllers
+

--- a/franka_example_controllers/msg/ArmsTargetPose.msg
+++ b/franka_example_controllers/msg/ArmsTargetPose.msg
@@ -1,0 +1,2 @@
+geometry_msgs/PoseStamped right_target
+geometry_msgs/PoseStamped left_target

--- a/franka_example_controllers/src/dual_arm_cartesian_pose_controller.cpp
+++ b/franka_example_controllers/src/dual_arm_cartesian_pose_controller.cpp
@@ -1,0 +1,424 @@
+// Copyright (c) 2019 Franka Emika GmbH
+// Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#include <franka_example_controllers/dual_arm_cartesian_pose_controller.h>
+
+#include <cmath>
+#include <functional>
+#include <memory>
+
+#include <controller_interface/controller_base.h>
+#include <eigen_conversions/eigen_msg.h>
+#include <franka/robot_state.h>
+#include <franka_example_controllers/pseudo_inversion.h>
+#include <franka_hw/trigger_rate.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <franka_example_controllers/ArmsTargetPose.h>
+#include <pluginlib/class_list_macros.h>
+#include <ros/ros.h>
+#include <ros/transport_hints.h>
+#include <tf/transform_listener.h>
+#include <tf_conversions/tf_eigen.h>
+
+namespace franka_example_controllers {
+
+bool DualArmCartesianPoseController::initArm(
+    hardware_interface::RobotHW* robot_hw,
+    const std::string& arm_id,
+    const std::vector<std::string>& joint_names) {
+  FrankaDataContainer arm_data;
+  auto* model_interface = robot_hw->get<franka_hw::FrankaModelInterface>();
+  if (model_interface == nullptr) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Error getting model interface from hardware");
+    return false;
+  }
+  try {
+    arm_data.model_handle_ = std::make_unique<franka_hw::FrankaModelHandle>(
+        model_interface->getHandle(arm_id + "_model"));
+  } catch (hardware_interface::HardwareInterfaceException& ex) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Exception getting model handle from "
+        "interface: "
+        << ex.what());
+    return false;
+  }
+
+  auto* state_interface = robot_hw->get<franka_hw::FrankaStateInterface>();
+  if (state_interface == nullptr) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Error getting state interface from hardware");
+    return false;
+  }
+  try {
+    arm_data.state_handle_ = std::make_unique<franka_hw::FrankaStateHandle>(
+        state_interface->getHandle(arm_id + "_robot"));
+  } catch (hardware_interface::HardwareInterfaceException& ex) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Exception getting state handle from "
+        "interface: "
+        << ex.what());
+    return false;
+  }
+
+  auto* effort_joint_interface = robot_hw->get<hardware_interface::EffortJointInterface>();
+  if (effort_joint_interface == nullptr) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Error getting effort joint interface from "
+        "hardware");
+    return false;
+  }
+  for (size_t i = 0; i < 7; ++i) {
+    try {
+      arm_data.joint_handles_.push_back(effort_joint_interface->getHandle(joint_names[i]));
+    } catch (const hardware_interface::HardwareInterfaceException& ex) {
+      ROS_ERROR_STREAM(
+          "DualArmCartesianPoseController: Exception getting joint handles: "
+          << ex.what());
+      return false;
+    }
+  }
+
+  arm_data.position_d_.setZero();
+  arm_data.orientation_d_.coeffs() << 0.0, 0.0, 0.0, 1.0;
+  arm_data.position_d_target_.setZero();
+  arm_data.orientation_d_target_.coeffs() << 0.0, 0.0, 0.0, 1.0;
+
+  arm_data.cartesian_stiffness_.setZero();
+  arm_data.cartesian_damping_.setZero();
+
+  arms_data_.emplace(std::make_pair(arm_id, std::move(arm_data)));
+
+  return true;
+}
+
+bool DualArmCartesianPoseController::init(hardware_interface::RobotHW* robot_hw,
+                                                      ros::NodeHandle& node_handle) {
+  std::vector<double> cartesian_stiffness_vector;
+  std::vector<double> cartesian_damping_vector;
+   if (!node_handle.getParam("left/arm_id", left_arm_id_)) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Could not read parameter left_arm_id_");
+    return false;
+  }
+  std::vector<std::string> left_joint_names;
+  if (!node_handle.getParam("left/joint_names", left_joint_names) || left_joint_names.size() != 7) {
+    ROS_ERROR(
+        "DualArmCartesianPoseController: Invalid or no left_joint_names parameters "
+        "provided, "
+        "aborting controller init!");
+    return false;
+  }
+
+  if (!node_handle.getParam("right/arm_id", right_arm_id_)) {
+    ROS_ERROR_STREAM(
+        "DualArmCartesianPoseController: Could not read parameter right_arm_id_");
+    return false;
+  }
+
+  // subscribe target pose
+  boost::function<void(const franka_example_controllers::ArmsTargetPose::ConstPtr&)> arms_callback =
+      boost::bind(&DualArmCartesianPoseController::targetArmsPoseCallback, this, _1);
+  ros::SubscribeOptions arms_subscribe_options;
+  arms_subscribe_options.init("arms_target_pose", 1, arms_callback);
+  arms_subscribe_options.transport_hints = ros::TransportHints().reliable().tcpNoDelay();
+  sub_arms_target_pose_ = node_handle.subscribe(arms_subscribe_options);
+
+  publish_rate_ = franka_hw::TriggerRate(30.0);
+  // just for visualizing
+  left_frame_pub_.init(node_handle, "left_frame", 1, true);
+  right_frame_pub_.init(node_handle, "right_frame", 1, true);
+
+
+  std::vector<std::string> right_joint_names;
+  if (!node_handle.getParam("right/joint_names", right_joint_names) ||
+      right_joint_names.size() != 7) {
+    ROS_ERROR(
+        "DualArmCartesianPoseController: Invalid or no right_joint_names parameters "
+        "provided, "
+        "aborting controller init!");
+    return false;
+  }
+
+  bool left_success = initArm(robot_hw, left_arm_id_, left_joint_names);
+  bool right_success = initArm(robot_hw, right_arm_id_, right_joint_names);
+
+  dynamic_reconfigure_compliance_param_node_ =
+      ros::NodeHandle("dynamic_reconfigure_compliance_param_node");
+
+  dynamic_server_compliance_param_ = std::make_unique<dynamic_reconfigure::Server<
+      franka_combined_example_controllers::dual_arm_compliance_paramConfig>>(
+      dynamic_reconfigure_compliance_param_node_);
+
+  dynamic_server_compliance_param_->setCallback(boost::bind(
+      &DualArmCartesianPoseController::complianceParamCallback, this, _1, _2));
+
+  // Get the transformation from right_O_frame to left_O_frame
+  tf::StampedTransform transform;
+  tf::TransformListener listener;
+  try {
+    if (listener.waitForTransform(left_arm_id_ + "_link0", right_arm_id_ + "_link0", ros::Time(0),
+                                  ros::Duration(4.0))) {
+      listener.lookupTransform(left_arm_id_ + "_link0", right_arm_id_ + "_link0", ros::Time(0),
+                               transform);
+    } else {
+      ROS_ERROR(
+          "DualArmCartesianPoseController: Failed to read transform from %s to %s. "
+          "Aborting init!",
+          (right_arm_id_ + "_link0").c_str(), (left_arm_id_ + "_link0").c_str());
+      return false;
+    }
+  } catch (tf::TransformException& ex) {
+    ROS_ERROR("DualArmCartesianPoseController: %s", ex.what());
+    return false;
+  }
+  tf::transformTFToEigen(transform, Ol_T_Or_);  // NOLINT (readability-identifier-naming)
+
+  return left_success && right_success;
+}
+
+void DualArmCartesianPoseController::startingArm(FrankaDataContainer& arm_data) {
+  // compute initial velocity with jacobian and set x_attractor and q_d_nullspace
+  // to initial configuration
+  franka::RobotState initial_state = arm_data.state_handle_->getRobotState();
+  // get jacobian
+  std::array<double, 42> jacobian_array =
+      arm_data.model_handle_->getZeroJacobian(franka::Frame::kEndEffector);
+  // convert to eigen
+  Eigen::Map<Eigen::Matrix<double, 6, 7>> jacobian(jacobian_array.data());
+  Eigen::Map<Eigen::Matrix<double, 7, 1>> dq_initial(initial_state.dq.data());
+  Eigen::Map<Eigen::Matrix<double, 7, 1>> q_initial(initial_state.q.data());
+  Eigen::Affine3d initial_transform(Eigen::Matrix4d::Map(initial_state.O_T_EE.data()));
+
+  // set target point to current state
+  arm_data.position_d_ = initial_transform.translation();
+  arm_data.orientation_d_ = Eigen::Quaterniond(initial_transform.linear());
+  arm_data.position_d_target_ = initial_transform.translation();
+  arm_data.orientation_d_target_ = Eigen::Quaterniond(initial_transform.linear());
+
+  // set nullspace target configuration to initial q
+  arm_data.q_d_nullspace_ = q_initial;
+}
+
+void DualArmCartesianPoseController::starting(const ros::Time& /*time*/) {
+  for (auto& arm_data : arms_data_) {
+    startingArm(arm_data.second);
+  }
+  franka::RobotState robot_state_right =
+      arms_data_.at(right_arm_id_).state_handle_->getRobotState();
+  franka::RobotState robot_state_left = arms_data_.at(left_arm_id_).state_handle_->getRobotState();
+  Eigen::Affine3d Ol_T_EEl(Eigen::Matrix4d::Map(  // NOLINT (readability-identifier-naming)
+      robot_state_left.O_T_EE.data()));           // NOLINT (readability-identifier-naming)
+  Eigen::Affine3d Or_T_EEr(Eigen::Matrix4d::Map(  // NOLINT (readability-identifier-naming)
+      robot_state_right.O_T_EE.data()));          // NOLINT (readability-identifier-naming)
+  EEr_T_EEl_ =
+      Or_T_EEr.inverse() * Ol_T_Or_.inverse() * Ol_T_EEl;  // NOLINT (readability-identifier-naming)
+  EEl_T_C_.setIdentity();
+  Eigen::Vector3d EEr_r_EEr_EEl =  // NOLINT (readability-identifier-naming)
+      EEr_T_EEl_.translation();    // NOLINT (readability-identifier-naming)
+  EEl_T_C_.translation() = -0.5 * EEr_T_EEl_.inverse().rotation() * EEr_r_EEr_EEl;
+}
+
+void DualArmCartesianPoseController::update(const ros::Time& /*time*/,
+                                                        const ros::Duration& /*period*/) {
+  for (auto& arm_data : arms_data_) {
+    updateArm(arm_data.second);
+  }
+  if (publish_rate_()) {
+    publishCurrentPose();
+  }
+}
+
+void DualArmCartesianPoseController::updateArm(FrankaDataContainer& arm_data) {
+  // get state variables
+  franka::RobotState robot_state = arm_data.state_handle_->getRobotState();
+  std::array<double, 49> inertia_array = arm_data.model_handle_->getMass();
+  std::array<double, 7> coriolis_array = arm_data.model_handle_->getCoriolis();
+  std::array<double, 42> jacobian_array =
+      arm_data.model_handle_->getZeroJacobian(franka::Frame::kEndEffector);
+
+  // convert to Eigen
+  Eigen::Map<Eigen::Matrix<double, 7, 1>> coriolis(coriolis_array.data());
+  Eigen::Map<Eigen::Matrix<double, 6, 7>> jacobian(jacobian_array.data());
+  Eigen::Map<Eigen::Matrix<double, 7, 1>> q(robot_state.q.data());
+  Eigen::Map<Eigen::Matrix<double, 7, 1>> dq(robot_state.dq.data());
+  Eigen::Map<Eigen::Matrix<double, 7, 1>> tau_J_d(  // NOLINT (readability-identifier-naming)
+      robot_state.tau_J_d.data());
+  Eigen::Affine3d transform(Eigen::Matrix4d::Map(robot_state.O_T_EE.data()));
+  Eigen::Vector3d position(transform.translation());
+  Eigen::Quaterniond orientation(transform.linear());
+
+  // compute error to desired pose
+  // position error
+  Eigen::Matrix<double, 6, 1> error;
+  error.head(3) << position - arm_data.position_d_;
+
+  // orientation error
+  if (arm_data.orientation_d_.coeffs().dot(orientation.coeffs()) < 0.0) {
+    orientation.coeffs() << -orientation.coeffs();
+  }
+  // "difference" quaternion
+  Eigen::Quaterniond error_quaternion(orientation * arm_data.orientation_d_.inverse());
+  // convert to axis angle
+  Eigen::AngleAxisd error_quaternion_angle_axis(error_quaternion);
+  // compute "orientation error"
+  error.tail(3) << error_quaternion_angle_axis.axis() * error_quaternion_angle_axis.angle();
+
+  // compute control
+  // allocate variables
+  Eigen::VectorXd tau_task(7), tau_nullspace(7), tau_d(7);
+
+  // pseudoinverse for nullspace handling
+  // kinematic pseuoinverse
+  Eigen::MatrixXd jacobian_transpose_pinv;
+  franka_example_controllers::pseudoInverse(jacobian.transpose(), jacobian_transpose_pinv);
+
+  // Cartesian PD control with damping ratio = 1
+  tau_task << jacobian.transpose() * (-arm_data.cartesian_stiffness_ * error -
+                                      arm_data.cartesian_damping_ * (jacobian * dq));
+  // nullspace PD control with damping ratio = 1
+  tau_nullspace << (Eigen::MatrixXd::Identity(7, 7) -
+                    jacobian.transpose() * jacobian_transpose_pinv) *
+                       (arm_data.nullspace_stiffness_ * (arm_data.q_d_nullspace_ - q) -
+                        (2.0 * sqrt(arm_data.nullspace_stiffness_)) * dq);
+  // Desired torque
+  tau_d << tau_task + tau_nullspace + coriolis;
+  // Saturate torque rate to avoid discontinuities
+  tau_d << saturateTorqueRate(arm_data, tau_d, tau_J_d);
+  for (size_t i = 0; i < 7; ++i) {
+    arm_data.joint_handles_[i].setCommand(tau_d(i));
+  }
+
+  // update parameters changed online either through dynamic reconfigure or through the interactive
+  // target by filtering
+  arm_data.cartesian_stiffness_ = arm_data.filter_params_ * arm_data.cartesian_stiffness_target_ +
+                                  (1.0 - arm_data.filter_params_) * arm_data.cartesian_stiffness_;
+  arm_data.cartesian_damping_ = arm_data.filter_params_ * arm_data.cartesian_damping_target_ +
+                                (1.0 - arm_data.filter_params_) * arm_data.cartesian_damping_;
+  arm_data.nullspace_stiffness_ = arm_data.filter_params_ * arm_data.nullspace_stiffness_target_ +
+                                  (1.0 - arm_data.filter_params_) * arm_data.nullspace_stiffness_;
+  arm_data.position_d_ = arm_data.filter_params_ * arm_data.position_d_target_ +
+                         (1.0 - arm_data.filter_params_) * arm_data.position_d_;
+  arm_data.orientation_d_ =
+      arm_data.orientation_d_.slerp(arm_data.filter_params_, arm_data.orientation_d_target_);
+}
+
+Eigen::Matrix<double, 7, 1> DualArmCartesianPoseController::saturateTorqueRate(
+    const FrankaDataContainer& arm_data,
+    const Eigen::Matrix<double, 7, 1>& tau_d_calculated,
+    const Eigen::Matrix<double, 7, 1>& tau_J_d) {  // NOLINT (readability-identifier-naming)
+  Eigen::Matrix<double, 7, 1> tau_d_saturated{};
+  for (size_t i = 0; i < 7; i++) {
+    double difference = tau_d_calculated[i] - tau_J_d[i];
+    tau_d_saturated[i] = tau_J_d[i] + std::max(std::min(difference, arm_data.delta_tau_max_),
+                                               -arm_data.delta_tau_max_);
+  }
+  return tau_d_saturated;
+}
+
+void DualArmCartesianPoseController::complianceParamCallback(
+    franka_combined_example_controllers::dual_arm_compliance_paramConfig& config,
+    uint32_t /*level*/) {
+  auto& left_arm_data = arms_data_.at(left_arm_id_);
+  left_arm_data.cartesian_stiffness_target_.setIdentity();
+  left_arm_data.cartesian_stiffness_target_.topLeftCorner(3, 3)
+      << config.left_translational_stiffness * Eigen::Matrix3d::Identity();
+  left_arm_data.cartesian_stiffness_target_.bottomRightCorner(3, 3)
+      << config.left_rotational_stiffness * Eigen::Matrix3d::Identity();
+  left_arm_data.cartesian_damping_target_.setIdentity();
+
+  left_arm_data.cartesian_damping_target_.topLeftCorner(3, 3)
+      << 2 * sqrt(config.left_translational_stiffness) * Eigen::Matrix3d::Identity();
+  left_arm_data.cartesian_damping_target_.bottomRightCorner(3, 3)
+      << 2 * sqrt(config.left_rotational_stiffness) * Eigen::Matrix3d::Identity();
+  left_arm_data.nullspace_stiffness_target_ = config.left_nullspace_stiffness;
+
+  auto& right_arm_data = arms_data_.at(right_arm_id_);
+  right_arm_data.cartesian_stiffness_target_.setIdentity();
+  right_arm_data.cartesian_stiffness_target_.topLeftCorner(3, 3)
+      << config.right_translational_stiffness * Eigen::Matrix3d::Identity();
+  right_arm_data.cartesian_stiffness_target_.bottomRightCorner(3, 3)
+      << config.right_rotational_stiffness * Eigen::Matrix3d::Identity();
+  right_arm_data.cartesian_damping_target_.setIdentity();
+
+  right_arm_data.cartesian_damping_target_.topLeftCorner(3, 3)
+      << 2 * sqrt(config.right_translational_stiffness) * Eigen::Matrix3d::Identity();
+  right_arm_data.cartesian_damping_target_.bottomRightCorner(3, 3)
+      << 2 * sqrt(config.right_rotational_stiffness) * Eigen::Matrix3d::Identity();
+  right_arm_data.nullspace_stiffness_target_ = config.right_nullspace_stiffness;
+}
+
+void DualArmCartesianPoseController::targetArmsPoseCallback(const franka_example_controllers::ArmsTargetPose::ConstPtr& msg){
+  const geometry_msgs::PoseStamped right_target = msg->right_target;
+  const geometry_msgs::PoseStamped left_target = msg->left_target;
+  try {
+    if (left_target.header.frame_id != left_arm_id_ + "_link0") {  // NOLINT
+      ROS_ERROR_STREAM(
+          "DualArmCartesianPoseController: Got pose target with invalid"
+          " frame_id "
+          << left_target.header.frame_id << ". Expected " << left_arm_id_ + "_link0");
+      return;
+    }
+    if (right_target.header.frame_id != right_arm_id_ + "_link0") {  // NOLINT
+      ROS_ERROR_STREAM(
+          "DualArmCartesianPoseController: Got pose target with invalid"
+          " frame_id "
+          << right_target.header.frame_id << ". Expected " << right_arm_id_ + "_link0");
+      return;
+    }
+    // Set target for the left robot.
+    auto& left_arm_data = arms_data_.at(left_arm_id_);
+    Eigen::Affine3d Ol_T_EEl_d{};  // NOLINT (readability-identifier-naming)
+    tf::poseMsgToEigen(left_target.pose, Ol_T_EEl_d);
+    left_arm_data.position_d_target_ = Ol_T_EEl_d.translation();
+    Eigen::Quaterniond l_last_orientation_d_target(left_arm_data.orientation_d_target_);
+    Eigen::Quaterniond l_new_orientation_target(Ol_T_EEl_d.linear());  // NOLINT
+    if (l_last_orientation_d_target.coeffs().dot(l_new_orientation_target.coeffs()) < 0.0) {
+      l_new_orientation_target.coeffs() << -l_new_orientation_target.coeffs();
+    }
+    Ol_T_EEl_d.linear() = l_new_orientation_target.matrix();
+    left_arm_data.orientation_d_target_ = Ol_T_EEl_d.linear();
+
+    // Set target for the right robot.
+    auto& right_arm_data = arms_data_.at(right_arm_id_);
+    Eigen::Affine3d Or_T_EEl_d{};  // NOLINT (readability-identifier-naming)
+    tf::poseMsgToEigen(right_target.pose, Or_T_EEl_d);
+    right_arm_data.position_d_target_ = Or_T_EEl_d.translation();
+    Eigen::Quaterniond r_last_orientation_d_target(right_arm_data.orientation_d_target_);
+    Eigen::Quaterniond r_new_orientation_target(Or_T_EEl_d.linear());  // NOLINT
+    if (r_last_orientation_d_target.coeffs().dot(r_new_orientation_target.coeffs()) < 0.0) {
+      r_new_orientation_target.coeffs() << -r_new_orientation_target.coeffs();
+    }
+    Or_T_EEl_d.linear() = r_new_orientation_target.matrix();
+    right_arm_data.orientation_d_target_ = Or_T_EEl_d.linear();
+  } catch (std::out_of_range& ex) {
+    ROS_ERROR_STREAM("DualArmCartesianPoseController: Exception setting target poses.");
+  }
+}
+
+void DualArmCartesianPoseController::publishCurrentPose() {
+  if (left_frame_pub_.trylock()) {
+    franka::RobotState robot_state_left =
+        arms_data_.at(left_arm_id_).state_handle_->getRobotState();
+    Eigen::Affine3d Ol_T_C(Eigen::Matrix4d::Map(  // NOLINT (readability-identifier-naming)
+        robot_state_left.O_T_EE.data()));           // NOLINT (readability-identifier-naming)
+    tf::poseEigenToMsg(Ol_T_C, left_frame_pub_.msg_.pose);
+    left_frame_pub_.msg_.header.frame_id = left_arm_id_ + "_link0";
+    left_frame_pub_.msg_.header.stamp = ros::Time::now();
+    left_frame_pub_.unlockAndPublish();
+  }
+  if (right_frame_pub_.trylock()) {
+    franka::RobotState robot_state_right =
+        arms_data_.at(right_arm_id_).state_handle_->getRobotState();
+    Eigen::Affine3d Or_T_C(Eigen::Matrix4d::Map(  // NOLINT (readability-identifier-naming)
+        robot_state_right.O_T_EE.data()));           // NOLINT (readability-identifier-naming)
+    tf::poseEigenToMsg(Or_T_C, right_frame_pub_.msg_.pose);
+    right_frame_pub_.msg_.header.frame_id = right_arm_id_ + "_link0";
+    right_frame_pub_.msg_.header.stamp = ros::Time::now();
+    right_frame_pub_.unlockAndPublish();
+  }
+}
+
+}  // namespace franka_example_controllers
+
+PLUGINLIB_EXPORT_CLASS(franka_example_controllers::DualArmCartesianPoseController,
+                       controller_interface::ControllerBase)


### PR DESCRIPTION
This PR adds DualArmCartesianPoseController to franka_example_controllers.
This controller is similar to [DualArmCartesianImpedanceExampleController](https://github.com/frankaemika/franka_ros/blob/0.9.0/franka_example_controllers/src/dual_arm_cartesian_impedance_example_controller.cpp) but is different from it in that this controller gets a different target pose (`geometry_msgs/PoseStamped`) for each arm.
This controller is useful for some teleoperations, where one haptic device (e.g., [Touch](https://www.3dsystems.com/haptics-devices/touch)) controls one arm.

This controller was originally written by @ykawamura96 ([original branch](https://github.com/pazeshun/franka_ros/tree/add_dual_arm_impedance_controller)) and refactored by @pazeshun