### PR TITLE
auto-recover from error

### DIFF
--- a/franka_control/src/franka_control_node.cpp
+++ b/franka_control/src/franka_control_node.cpp
@@ -139,6 +139,7 @@ int main(int argc, char** argv) {
       }
     }
 
+    ROS_INFO_THROTTLE(1, "franka_control: controller activated");
     if (franka_control.connected()) {
       try {
         // Run control loop. Will exit if the controller is switched.
@@ -160,7 +161,7 @@ int main(int argc, char** argv) {
         has_error = true;
       }
     }
-    ROS_INFO_THROTTLE(1, "franka_control, main loop");
+    ROS_INFO_THROTTLE(1, "franka_control: main loop");
   }
 
   return 0;

--- a/franka_control/src/franka_control_node.cpp
+++ b/franka_control/src/franka_control_node.cpp
@@ -124,6 +124,10 @@ int main(int argc, char** argv) {
           control_manager.update(now, now - last_time);
           franka_control.checkJointLimits();
           last_time = now;
+
+          if (has_error && franka_control.robotMode() == franka::RobotMode::kIdle) {
+            has_error = false;
+          }
         } catch (const std::logic_error& e) {
         }
       } else {

--- a/franka_hw/include/franka_hw/franka_hw.h
+++ b/franka_hw/include/franka_hw/franka_hw.h
@@ -295,6 +295,8 @@ class FrankaHW : public hardware_interface::RobotHW {
                                                     const ros::NodeHandle& robot_hw_nh,
                                                     const std::vector<double>& defaults);
 
+  franka::RobotMode robotMode() const { return robot_state_ros_.robot_mode; }
+
  protected:
   /**
    * Checks whether an array of doubles contains NaN values.


### PR DESCRIPTION
This implements auto-recovering from errors when the user-stop button is pressed+unpressed and thus the robot's mode switches to idle. Without that, one has to trigger the `error_recovery` action.
Partially fixes #232