### PR TITLE
Fix various issues in TriggerRate

### DIFF
--- a/franka_hw/include/franka_hw/trigger_rate.h
+++ b/franka_hw/include/franka_hw/trigger_rate.h
@@ -13,7 +13,7 @@ class TriggerRate {
 
  private:
   ros::Time time_stamp_;
-  double period_;
+  ros::Duration period_;
 };
 
 };  // namespace franka_hw

--- a/franka_hw/src/trigger_rate.cpp
+++ b/franka_hw/src/trigger_rate.cpp
@@ -7,7 +7,7 @@ namespace franka_hw {
 TriggerRate::TriggerRate(double rate) : period_(1.0 / rate), time_stamp_(ros::Time::now()) {}
 
 bool TriggerRate::operator()() {
-  if ((ros::Time::now() - time_stamp_).toSec() > period_) {
+  if ((ros::Time::now() - time_stamp_).toSec() >= period_) {
     time_stamp_ = ros::Time::now();
     return true;
   }

--- a/franka_hw/src/trigger_rate.cpp
+++ b/franka_hw/src/trigger_rate.cpp
@@ -8,7 +8,7 @@ TriggerRate::TriggerRate(double rate) : period_(1.0 / rate), time_stamp_(ros::Ti
 
 bool TriggerRate::operator()() {
   auto now = ros::Time::now();
-  if (now - time_stamp_ >= period_) {
+  if (now - time_stamp_ >= period_ || now < time_stamp_) {
     time_stamp_ = now;
     return true;
   }

--- a/franka_hw/src/trigger_rate.cpp
+++ b/franka_hw/src/trigger_rate.cpp
@@ -7,7 +7,7 @@ namespace franka_hw {
 TriggerRate::TriggerRate(double rate) : period_(1.0 / rate), time_stamp_(ros::Time::now()) {}
 
 bool TriggerRate::operator()() {
-  if ((ros::Time::now() - time_stamp_).toSec() >= period_) {
+  if (ros::Time::now() - time_stamp_ >= period_) {
     time_stamp_ = ros::Time::now();
     return true;
   }

--- a/franka_hw/src/trigger_rate.cpp
+++ b/franka_hw/src/trigger_rate.cpp
@@ -7,8 +7,9 @@ namespace franka_hw {
 TriggerRate::TriggerRate(double rate) : period_(1.0 / rate), time_stamp_(ros::Time::now()) {}
 
 bool TriggerRate::operator()() {
-  if (ros::Time::now() - time_stamp_ >= period_) {
-    time_stamp_ = ros::Time::now();
+  auto now = ros::Time::now();
+  if (now - time_stamp_ >= period_) {
+    time_stamp_ = now;
     return true;
   }
   return false;


### PR DESCRIPTION
In order to actually reach the desired rate, the inequality needs to be replaced with greater equal.
Here is an example with `publish_rate = 50` and Gazebo simulation (i.e. perfect sim time)

**Before**: rate = 47.619 Hz = 1/21ms
```
rostopic hz /franka_state_controller/joint_states
subscribed to [/franka_state_controller/joint_states]
WARNING: may be using simulated time
average rate: 47.619
        min: 0.019s max: 0.024s std dev: 0.00086s window: 143
```
**After**: rate = 50 Hz = 1/20ms (as expected)
```
average rate: 50.000
        min: 0.018s max: 0.022s std dev: 0.00063s window: 52
```