### PR TITLE
[franka_hw] Install plugin xml to enable to load FrankaCombinableHW from apt version of franka_hw

### DIFF
--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -110,6 +110,9 @@ install(TARGETS franka_hw franka_control_services
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
+install(FILES franka_combinable_hw_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 ## Tools
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/ClangTools.cmake OPTIONAL


### PR DESCRIPTION
When I try to load `franka_hw/FrankaCombinableHW` from apt version of `franka_hw`, I faced the following error:
```
[ERROR] [/dual_panda] [1668147868.535937528]: Skipped loading plugin with error: XML Document '/opt/ros/melodic/share/franka_hw/franka_combinable_hw_plugin.xml' has no Root Element. This likely means the XML is malformed or missing..
[ERROR] [/dual_panda] [1668147868.537817487]: Could not load robot HW 'rarm' because robot HW type 'franka_hw/FrankaCombinableHW' does not exist.
[ERROR] [/dual_panda] [1668147868.555089521]: franka_combined_control_node:: Initialization of FrankaCombinedHW failed!
```
This is because `franka_hw/franka_combinable_hw_plugin.xml` is not installed:
https://github.com/frankaemika/franka_ros/blob/a58d3052a241304392847df6464234c83d728a38/franka_hw/CMakeLists.txt#L104-L112

This PR installs `franka_hw/franka_combinable_hw_plugin.xml`.
I confirmed this PR works by:
```
catkin init
catkin config --install
catkin build
source <WORKSPACE_PATH>/install/setup.bash
```

cf. https://answers.ros.org/question/274849/gmapping-skipping-xml-document/