### PR TITLE
fix gazebo velocity control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Requires `libfranka` >= 0.8.0
 
-  * `franka_gazebo`: Offer both `panda.launch` and `fr3.launch`
+  * `franka_gazebo`: Offer both `panda.launch` and `fr3.launch`.
+  * `franka_gazebo`: Fix velocity control by adding the missing effort.
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -482,7 +482,7 @@ void FrankaHWSim::writeSim(ros::Time /*time*/, ros::Duration period) {
     } else if (joint->control_method == POSITION) {
       effort = positionControl(*joint, joint->desired_position, period);
     } else if (joint->control_method == VELOCITY) {
-      velocityControl(*joint, joint->desired_velocity, period);
+      effort = velocityControl(*joint, joint->desired_velocity, period);
     } else if (joint->control_method == EFFORT) {
       // Feed-forward commands in effort control
       effort = joint->command;


### PR DESCRIPTION
The efforts computed by the velocity PID controllers were discarded before. Now they are applied to the joints just like with the position control PIDs.