### PR TITLE
Add missing arm_id parameter to JointVelocityExampleController config

### DIFF
--- a/franka_gazebo/config/sim_controllers.yaml
+++ b/franka_gazebo/config/sim_controllers.yaml
@@ -89,6 +89,7 @@ position_joint_trajectory_controller:
 
 joint_velocity_example_controller:
     type: franka_example_controllers/JointVelocityExampleController
+    arm_id: $(arg arm_id)
     joint_names:
         - $(arg arm_id)_joint1
         - $(arg arm_id)_joint2


### PR DESCRIPTION
With Gazebo, the `JointVelocityExampleController` fails with the following error:
`[ERROR] [1671708722.634915401] [ros.franka_example_controllers] [/mujoco_server]: JointVelocityExampleController: Could not get parameter arm_id`