### PR TITLE
Fix order of include directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_gazebo`: Offer both `panda.launch` and `fr3.launch`.
   * `franka_gazebo`: Fix velocity control by adding the missing effort.
   * `franka_control`: Clear the error flag if the robot is in `kIdle` mode, i.e. ready to move.
+  * Fix a possible compilation error by sorting include directories by topological order ([#319](https://github.com/frankaemika/franka_ros/issues/319)).
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
-# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+# merge Franka + catkin INCLUDE_DIRS in topological order
 list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 catkin_package(

--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -25,6 +25,9 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
+# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES franka_state_controller
@@ -60,7 +63,6 @@ target_link_libraries(franka_state_controller
 )
 
 target_include_directories(franka_state_controller SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 target_include_directories(franka_state_controller PUBLIC
@@ -83,7 +85,6 @@ target_link_libraries(franka_control_node
 )
 
 target_include_directories(franka_control_node SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -31,6 +31,9 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
+# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
 add_message_files(FILES
   JointTorqueComparison.msg
 )
@@ -97,7 +100,6 @@ target_link_libraries(franka_example_controllers PUBLIC
 )
 
 target_include_directories(franka_example_controllers SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
-# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+# merge Franka + INCLUDE_DIRS in topological order
 list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_message_files(FILES

--- a/franka_gazebo/CMakeLists.txt
+++ b/franka_gazebo/CMakeLists.txt
@@ -44,6 +44,9 @@ endif()
 find_package(Eigen3 REQUIRED)
 find_package(orocos_kdl REQUIRED)
 
+# merge Franka + catkin INCLUDE_DIRS in topological order
+list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
 catkin_package(
   CATKIN_DEPENDS
     roscpp
@@ -96,7 +99,6 @@ target_link_libraries(franka_hw_sim
   ${orocos_kdl_LIBRARIES}
   )
 target_include_directories(franka_hw_sim SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
   ${orocos_kdl_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -19,6 +19,10 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
+# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+list_insert_in_workspace_order(catkin_LIBRARIES ${Franka_LIBRARIES} ${catkin_LIBRARIES})
+list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
 add_action_files(
   DIRECTORY action
   FILES Grasp.action
@@ -63,7 +67,6 @@ target_link_libraries(franka_gripper
 )
 
 target_include_directories(franka_gripper SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 target_include_directories(franka_gripper PUBLIC

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -19,8 +19,7 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
-# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
-list_insert_in_workspace_order(catkin_LIBRARIES ${Franka_LIBRARIES} ${catkin_LIBRARIES})
+# merge Franka + catkin INCLUDE_DIRS in topological order
 list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_action_files(

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -23,6 +23,9 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
+# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES franka_hw franka_control_services
@@ -62,7 +65,6 @@ target_link_libraries(franka_hw
 )
 
 target_include_directories(franka_hw SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 target_include_directories(franka_hw PUBLIC
@@ -89,7 +91,6 @@ target_link_libraries(franka_control_services
 )
 
 target_include_directories(franka_control_services SYSTEM PUBLIC
-  ${Franka_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
-# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+# merge Franka + catkin INCLUDE_DIRS in topological order
 list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 catkin_package(

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -14,6 +14,9 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
+# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
 catkin_package(CATKIN_DEPENDS sensor_msgs roscpp)
 
 set(EXECUTABLES robot_joint_state_publisher gripper_joint_state_publisher)
@@ -27,7 +30,6 @@ foreach(executable ${EXECUTABLES})
     ${catkin_EXPORTED_TARGETS}
   )
   target_include_directories(${executable} SYSTEM PUBLIC
-    ${Franka_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
   )
   target_link_libraries(${executable} PUBLIC

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT Franka_FOUND)
   find_package(Franka 0.8.0 REQUIRED)
 endif()
 
-# merge Franka + catkin LIBRARIES/INCLUDE_DIRS in topological order
+# merge Franka + catkin INCLUDE_DIRS in topological order
 list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${Franka_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 catkin_package(CATKIN_DEPENDS sensor_msgs roscpp)


### PR DESCRIPTION
The reason for #319 is that `libfranka_INCLUDE_DIRS` points to `/opt/ros/*/include` and thus also pulls in all `franka_ros` include directories _before_ those from the overlay. The only clean solution is to sort include directories by topological order.
Fixes #319.