### PR TITLE
fix: Unexpected long delay when calling error recovery (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_gazebo`: Offer both `panda.launch` and `fr3.launch`.
   * `franka_gazebo`: Fix velocity control by adding the missing effort.
   * `franka_control`: Clear the error flag if the robot is in `kIdle` mode, i.e. ready to move.
+  * `franka_control`: Fix unexpected long delay when calling error recovery ([#317](https://github.com/frankaemika/franka_ros/issues/317))
   * Fix a possible compilation error by sorting include directories by topological order ([#319](https://github.com/frankaemika/franka_ros/issues/319)).
 
 ## 0.10.1 - 2022-09-15

--- a/franka_control/src/franka_control_node.cpp
+++ b/franka_control/src/franka_control_node.cpp
@@ -130,6 +130,7 @@ int main(int argc, char** argv) {
           }
         } catch (const std::logic_error& e) {
         }
+        std::this_thread::yield();
       } else {
         std::this_thread::sleep_for(1ms);
       }


### PR DESCRIPTION
Locking of mutex in the busy loop causes long delay when calling error recovery because executing error recovery requires the same mutex. Fixes #317.