### PR TITLE
fix: `error_recovery` action should not recover future errors (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_gazebo`: Fix velocity control by adding the missing effort.
   * `franka_control`: Clear the error flag if the robot is in `kIdle` mode, i.e. ready to move.
   * Fix a possible compilation error by sorting include directories by topological order ([#319](https://github.com/frankaemika/franka_ros/issues/319)).
+  * `franka_control`: Fix a bug where `error_recovery` actions recover future errors ([#316](https://github.com/frankaemika/franka_ros/issues/316)).
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_control/src/franka_control_node.cpp
+++ b/franka_control/src/franka_control_node.cpp
@@ -48,6 +48,13 @@ int main(int argc, char** argv) {
         std::make_unique<actionlib::SimpleActionServer<franka_msgs::ErrorRecoveryAction>>(
             node_handle, "error_recovery",
             [&](const franka_msgs::ErrorRecoveryGoalConstPtr&) {
+              if (!has_error) {
+                recovery_action_server->setSucceeded();
+                ROS_WARN(
+                    "Error recovery is unnecessary as no errors have been detected currently.");
+                return;
+              }
+
               try {
                 std::lock_guard<std::mutex> lock(franka_control.robotMutex());
                 robot.automaticErrorRecovery();


### PR DESCRIPTION
Previously, once `error_recovery` action is called during a motion, the action callback function will wait at the "mutex lock" until the motion stops. If the motion stops due to an error, the error will be recovered immediately which often results in an unexpected behavior of the robot.

This fix lets the action callback return early if there is no error present.

Fixes #316 