### PR TITLE
chore: remove cmake minium version deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_description`: `<xacro:franka_robot/>` macro now supports to customize the `parent` frame and its `xyz` + `rpy` offset
   * `franka_hw`: Fix the bug where the previous controller is still running after switching the controller. ([#326](https://github.com/frankaemika/franka_ros/issues/326))
   * `franka_gazebo`: Add `set_franka_model_configuration` service.
+  * Update minimum CMake version to 3.10 to remove deprecation warnings
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_control)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/franka_description/CMakeLists.txt
+++ b/franka_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_description)
 
 find_package(catkin REQUIRED)

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_example_controllers)
 
 set(CMAKE_BUILD_TYPE Release)

--- a/franka_gazebo/CMakeLists.txt
+++ b/franka_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_gazebo)
 
 execute_process(COMMAND uname -m

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_gripper)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_hw)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/franka_msgs/CMakeLists.txt
+++ b/franka_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs sensor_msgs actionlib_msgs)

--- a/franka_ros/CMakeLists.txt
+++ b/franka_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.3)
 project(franka_ros)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(franka_visualization)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Not sure if this is desirable given back-compatibility, but this pull request ensures that the cmake minimum version < 3.5 deprecation warning is no longer thrown:

```bash
Warnings   << catkin_tools_prebuild:cmake /home/ricks/development/work/franka_ros_ws/logs/catkin_tools_prebuild/build.cmake.000.log                                                                        
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):                                                                                                                                    
  Compatibility with CMake < 3.5 will be removed from a future version of                                                                                                                                  
  CMake.                                                                                                                                                                                                   
                                                                                                                                                                                                           
  Update the VERSION argument <min> value or use a ...<max> suffix to tell                                                                                                                                 
  CMake that the project does not need compatibility with older versions. 
```
