### PR TITLE
Update checkout action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         mkdir -p ${{github.workspace}}/devel     # compilation cache for formatter & linter
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/franka_ros
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Requires `libfranka` >= 0.8.0
     - Improve Gazebo 'stone' world objects
     - Introduce new `tau_ext_lowpass_filter` parameter for `franka_gazebo` to configure the filtering of `tau_ext_hat_filtered`
     - Add realistic hand/finger collision geometries to the Gazebo robot description
+    - Fix: `gripper_action` goes now to the commanded gripper position when `max_effort` is zero
   * Fix: Allow interactive marker server to shut down if not initialized
   * No further ROS Kinetic support, since [End-of-Life was in April 2021](http://wiki.ros.org/Distributions)
   * Make position + orientation targets threadsafe in cartesian example controller
@@ -28,175 +29,175 @@ Requires `libfranka` >= 0.8.0
 
 Requires `libfranka` >= 0.8.0
 
-  * `franka_hw`:
-    - Add `bool hasError()` member function to `FrankaCombinableHW`
-    - Only execute controller update in `franka_combined_control_node` when not in error state
-    - Reset command buffer upon recover in `FrankaCombinableHW`
+-   `franka_hw`:
+    -   Add `bool hasError()` member function to `FrankaCombinableHW`
+    -   Only execute controller update in `franka_combined_control_node` when not in error state
+    -   Reset command buffer upon recover in `FrankaCombinableHW`
 
 ## 0.8.0 - 2021-08-03
 
 Requires `libfranka` >= 0.8.0
 
-  * `franka_hw`, `franka_combinable_hw`, `franka_combined_hw`: Added service interface to disconnect
+-   `franka_hw`, `franka_combinable_hw`, `franka_combined_hw`: Added service interface to disconnect
     and reconnect when no controller is active. This allows mixing FCI- and DESK-based application
     without stopping the according hardware nodes.
-  * **BREAKING** `franka_hw`, `franka_combinable_hw` method control() now is non-const to allow
+-   **BREAKING** `franka_hw`, `franka_combinable_hw` method control() now is non-const to allow
     locking a mutex member variable.
-  * **BREAKING** Change behavior of `franka_msgs/SetEEFrame`. Previously, this method would set
+-   **BREAKING** Change behavior of `franka_msgs/SetEEFrame`. Previously, this method would set
     the flange-to-end-effector transformation `F_T_EE`. This has been split up into two transformations:
     `F_T_NE`, only settable in Desk, and `NE_T_EE`, which can be set in `franka_ros` with `SetEEFrame`
     and defaults to the identity transformation.
-  * Add `F_T_NE` and `NE_T_EE` to `franka_msgs/FrankaState`.
-  * _Franka Gazebo Integration_: Now you can simulate Panda robots in Gazebo including:
-    * gravity compensation
-    * non-realtime commands like `setEEFrame` or `setLoad`
-    * gripper simulation with the _same_ action interface as `franka_gripper`
-    * estimated inertias in the URDF
-    * no need to change existing ROS controllers
-    * only torque control supported in this version
-  * Extract Model Library in abstract base class interface. This allows users to implement their own model.
-  * **BREAKING** Remove `panda_arm_hand.urdf.xacro`. Use `panda_arm.urdf.xacro hand:=true` instead.
+-   Add `F_T_NE` and `NE_T_EE` to `franka_msgs/FrankaState`.
+-   _Franka Gazebo Integration_: Now you can simulate Panda robots in Gazebo including:
+    -   gravity compensation
+    -   non-realtime commands like `setEEFrame` or `setLoad`
+    -   gripper simulation with the _same_ action interface as `franka_gripper`
+    -   estimated inertias in the URDF
+    -   no need to change existing ROS controllers
+    -   only torque control supported in this version
+-   Extract Model Library in abstract base class interface. This allows users to implement their own model.
+-   **BREAKING** Remove `panda_arm_hand.urdf.xacro`. Use `panda_arm.urdf.xacro hand:=true` instead.
 
 ## 0.7.1 - 2020-10-22
 
 Requires `libfranka` >= 0.7.0
 
-  * `franka_example_controllers`: Added example for dual-arm teleoperation based on `franka_combinable_hw`.
-  * `franka_gripper`: Made stopping on shutdown optional.
-  * `franka_hw`: Added `franka_control_services` install instruction.
+-   `franka_example_controllers`: Added example for dual-arm teleoperation based on `franka_combinable_hw`.
+-   `franka_gripper`: Made stopping on shutdown optional.
+-   `franka_hw`: Added `franka_control_services` install instruction.
 
 ## 0.7.0 - 2020-07-15
 
 Requires `libfranka` >= 0.7.0
 
-  * **BREAKING** moved services and action from `franka_control` to `franka_msgs`.
-  * **BREAKING** moved Service container from `franka_control` to `franka_hw`.
-  * `franka_example_controllers`: Added example for dual-arm control based on `franka_combinable_hw`.
-  * `franka_description` :
-    - Added an example urdf with two panda arms.
-    - **BREAKING** Updated collision volumes.
-    - Removed invalid `axis` for `joint8`.
-  * `franka_hw`:
-    - Added hardware classes to support torque-controlling multiple robots from one controller.
-    - Refactored FrankaHW class to serve as base class (e.g. for FrankaCombinableHW).
-    - Added joint limits checking to FrankaHW which means parameterized warning prints when approaching limits.
-    - Made initial collision behavior a parameter.
-    - Added default constructor and init method to FrankaHW.
-    - **BREAKING** moved parsing of parameters from control node to FrankaHW::init.
-    - **BREAKING** made libfranka robot a member of FrankaHW.
-    - Added missing return value to `franka::ControllerMode` stream operator function.
-  * `franka_control`:
-    - Added control node that can runs a `FrankaCombinedHW` to control mulitple Pandas.
-    - Publish whole `libfranka` `franka::RobotState` in `franka_state_controller`.
-  * `franka_example_controllers`:
-    - Cartesian impedance example controller: Interpolate desired orientations with slerp and change orientation error
-      to quaternion.
-  * **BREAKING** Moved `panda_moveit_config` to [`ros-planning`](https://github.com/ros-planning/panda_moveit_config).
-  * Added support for ROS Melodic Morenia.
-  * Raised minimum CMake version to 3.4 to match `libfranka`.
-  * Add rosparam to choose value of `franka::RealtimeConfig`.
-  * Fix unused parameter bugs in `FrankaModelHandle` (#78).
-  * Added (experimental) support for ROS Noetic Ninjemys.
+-   **BREAKING** moved services and action from `franka_control` to `franka_msgs`.
+-   **BREAKING** moved Service container from `franka_control` to `franka_hw`.
+-   `franka_example_controllers`: Added example for dual-arm control based on `franka_combinable_hw`.
+-   `franka_description` :
+    -   Added an example urdf with two panda arms.
+    -   **BREAKING** Updated collision volumes.
+    -   Removed invalid `axis` for `joint8`.
+-   `franka_hw`:
+    -   Added hardware classes to support torque-controlling multiple robots from one controller.
+    -   Refactored FrankaHW class to serve as base class (e.g. for FrankaCombinableHW).
+    -   Added joint limits checking to FrankaHW which means parameterized warning prints when approaching limits.
+    -   Made initial collision behavior a parameter.
+    -   Added default constructor and init method to FrankaHW.
+    -   **BREAKING** moved parsing of parameters from control node to FrankaHW::init.
+    -   **BREAKING** made libfranka robot a member of FrankaHW.
+    -   Added missing return value to `franka::ControllerMode` stream operator function.
+-   `franka_control`:
+    -   Added control node that can runs a `FrankaCombinedHW` to control mulitple Pandas.
+    -   Publish whole `libfranka` `franka::RobotState` in `franka_state_controller`.
+-   `franka_example_controllers`:
+    -   Cartesian impedance example controller: Interpolate desired orientations with slerp and change orientation error
+        to quaternion.
+-   **BREAKING** Moved `panda_moveit_config` to [`ros-planning`](https://github.com/ros-planning/panda_moveit_config).
+-   Added support for ROS Melodic Morenia.
+-   Raised minimum CMake version to 3.4 to match `libfranka`.
+-   Add rosparam to choose value of `franka::RealtimeConfig`.
+-   Fix unused parameter bugs in `FrankaModelHandle` (#78).
+-   Added (experimental) support for ROS Noetic Ninjemys.
 
 ## 0.6.0 - 2018-08-08
 
 Requires `libfranka` >= 0.5.0
 
-  * **BREAKING** Fixes for MoveIt, improving robot performance:
-    * Fixed joint velocity and acceleration limits in `joint_limits.yaml`
-    * Use desired joint state for move group
-  * **BREAKING** Updated joint limits in URDF
-  * **BREAKING** Fixed velocity, acceleration and jerk limits in `franka_hw`
-  * **BREAKING** Start `franka_gripper_node` when giving `load_gripper:=true` to `franka_control.launch`
-  * Allow to configure rate limiting, filtering and internal controller in `franka_control_node`
-  * **BREAKING** `FrankaHW::FrankaHW` takes additional parameters.
-  * **BREAKING** Enabled rate limiting and low-pass filtering by default (`franka_control_node.yaml`)
-  * Publish desired joint state in `/joint_state_desired`
-  * Removed `effort_joint_trajectory_controller` from `default_controllers.yaml`
-  * Fixed a bug when switching between controllers using the same `libfranka` interface
+-   **BREAKING** Fixes for MoveIt, improving robot performance:
+    -   Fixed joint velocity and acceleration limits in `joint_limits.yaml`
+    -   Use desired joint state for move group
+-   **BREAKING** Updated joint limits in URDF
+-   **BREAKING** Fixed velocity, acceleration and jerk limits in `franka_hw`
+-   **BREAKING** Start `franka_gripper_node` when giving `load_gripper:=true` to `franka_control.launch`
+-   Allow to configure rate limiting, filtering and internal controller in `franka_control_node`
+-   **BREAKING** `FrankaHW::FrankaHW` takes additional parameters.
+-   **BREAKING** Enabled rate limiting and low-pass filtering by default (`franka_control_node.yaml`)
+-   Publish desired joint state in `/joint_state_desired`
+-   Removed `effort_joint_trajectory_controller` from `default_controllers.yaml`
+-   Fixed a bug when switching between controllers using the same `libfranka` interface
 
 ## 0.5.0 - 2018-06-28
 
 Requires `libfranka` >= 0.4.0
 
-  * **BREAKING** Updated URDF:
-    * Adjusted maximum joint velocity
-    * Updated axis 4 hard and soft limits
+-   **BREAKING** Updated URDF:
+    -   Adjusted maximum joint velocity
+    -   Updated axis 4 hard and soft limits
 
 ## 0.4.1 - 2018-06-21
 
 Requires `libfranka` >= 0.3.0
 
-  * Added some missing includes to `franka_hw`
-  * Add support for commanding elbow in Cartesian pose and Cartesian velocity interfaces
+-   Added some missing includes to `franka_hw`
+-   Add support for commanding elbow in Cartesian pose and Cartesian velocity interfaces
 
 ## 0.4.0 - 2018-03-26
 
 Requires `libfranka` >= 0.3.0
 
-  * **BREAKING** Removed `arm_id` and default `robot_ip` from launchfiles
-  * **BREAKING** Changed namespace of `franka_control` controller manager
-  * **BREAKING** Changed behavior of `gripper_action` for compatibility with MoveIt
-  * Changes in `panda_moveit_config`:
-    * Updated joint limits from URDF
-    * Removed `home` poses
-    * Fixed fake execution
-    * Add `load_gripper` argument (default: `true`) to `panda_moveit.launch`
-    * Conditionally load controllers/SRDFs based on `load_gripper`
-    * Add gripper controller configuration (requires running `franka_gripper_node`)
-  * Added `mimic` tag for gripper fingers to URDF and fixed velocity limits
+-   **BREAKING** Removed `arm_id` and default `robot_ip` from launchfiles
+-   **BREAKING** Changed namespace of `franka_control` controller manager
+-   **BREAKING** Changed behavior of `gripper_action` for compatibility with MoveIt
+-   Changes in `panda_moveit_config`:
+    -   Updated joint limits from URDF
+    -   Removed `home` poses
+    -   Fixed fake execution
+    -   Add `load_gripper` argument (default: `true`) to `panda_moveit.launch`
+    -   Conditionally load controllers/SRDFs based on `load_gripper`
+    -   Add gripper controller configuration (requires running `franka_gripper_node`)
+-   Added `mimic` tag for gripper fingers to URDF and fixed velocity limits
 
 ## 0.3.0 - 2018-02-22
 
 Requires `libfranka` >= 0.3.0
 
-  * **BREAKING** Changed signatures in `franka_hw::FrankaModelHandle`
-  * **BREAKING** Added epsilon parameters to `franka_gripper/Grasp` action
-  * Added Collada meshes for Panda and Hand
-  * Added missing dependencies to `panda_moveit_config` and `franka_example_controllers`
-  * Fixed linker errors when building with `-DFranka_DIR` while an older version of
+-   **BREAKING** Changed signatures in `franka_hw::FrankaModelHandle`
+-   **BREAKING** Added epsilon parameters to `franka_gripper/Grasp` action
+-   Added Collada meshes for Panda and Hand
+-   Added missing dependencies to `panda_moveit_config` and `franka_example_controllers`
+-   Fixed linker errors when building with `-DFranka_DIR` while an older version of
     `ros-kinetic-libfranka` is installed
-  * Added gripper joint state publisher to `franka_visualization`
-  * Moved `move_to_start.py` example script to `franka_example_controllers`
+-   Added gripper joint state publisher to `franka_visualization`
+-   Moved `move_to_start.py` example script to `franka_example_controllers`
 
 ## 0.2.2 - 2018-01-31
 
 Requires `libfranka` >= 0.2.0
 
-  * Catkin-related fixes for `franka_example_controllers`
-  * Added missing `<build_export_depend>` for `message_runtime`
+-   Catkin-related fixes for `franka_example_controllers`
+-   Added missing `<build_export_depend>` for `message_runtime`
 
 ## 0.2.1 - 2018-01-30
 
 Requires `libfranka` >= 0.2.0
 
-  * Added missing dependency to `franka_example_controllers`
-  * Lowered rotational gains for Cartesian impedance example controller
+-   Added missing dependency to `franka_example_controllers`
+-   Lowered rotational gains for Cartesian impedance example controller
 
 ## 0.2.0 - 2018-01-29
 
 Requires `libfranka` >= 0.2.0
 
-  * Added missing run-time dependencies to `franka_description` and `franka_control`
-  * Added `tau_J_d`, `m_ee`, `F_x_Cee`, `I_ee`, `m_total`, `F_x_Ctotal`, `I_total`,
+-   Added missing run-time dependencies to `franka_description` and `franka_control`
+-   Added `tau_J_d`, `m_ee`, `F_x_Cee`, `I_ee`, `m_total`, `F_x_Ctotal`, `I_total`,
     `theta` and `dtheta` to `franka_msgs/FrankaState`
-  * Added new errors to `franka_msgs/Errors`
-  * Updated and improved examples in `franka_example_controllers`
-  * Fixed includes for Eigen3 in `franka_example_controllers`
-  * Fixed gripper state publishing in `franka_gripper_node`
+-   Added new errors to `franka_msgs/Errors`
+-   Updated and improved examples in `franka_example_controllers`
+-   Fixed includes for Eigen3 in `franka_example_controllers`
+-   Fixed gripper state publishing in `franka_gripper_node`
 
 ## 0.1.2 - 2017-10-10
 
-  * Fixed out-of-workspace build
+-   Fixed out-of-workspace build
 
 ## 0.1.1 - 2017-10-09
 
-  * Integrated `franka_description` as subdirectory
-  * Fixed dependencies on libfranka
-  * Fixed RViz config file paths
-  * Added missing `test_depend` to `franka_hw`
-  * Added missing CMake install rules
+-   Integrated `franka_description` as subdirectory
+-   Fixed dependencies on libfranka
+-   Fixed RViz config file paths
+-   Added missing `test_depend` to `franka_hw`
+-   Added missing CMake install rules
 
 ## 0.1.0 - 2017-09-15
 
-  * Initial release
+-   Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Requires `libfranka` >= 0.8.0
     - Improve Gazebo 'stone' world objects
     - Introduce new `tau_ext_lowpass_filter` parameter for `franka_gazebo` to configure the filtering of `tau_ext_hat_filtered`
     - Add realistic hand/finger collision geometries to the Gazebo robot description
+    - Add `set_franka_model_configuration` service.
   * Fix: Allow interactive marker server to shut down if not initialized
   * No further ROS Kinetic support, since [End-of-Life was in April 2021](http://wiki.ros.org/Distributions)
   * Make position + orientation targets threadsafe in cartesian example controller

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -1,12 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
 
-  <!-- Name of this panda -->
-  <xacro:arg name="arm_id" default="panda" />
-  <!-- Should a franka_gripper be mounted at the flange?" -->
-  <xacro:arg name="hand" default="false" />
-  <!-- Is the robot being simulated in gazebo?" -->
-  <xacro:arg name="gazebo" default="false" />
+  <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
+  <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
+  <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
+  <xacro:arg name="transmission" default="hardware_interface/EffortJointInterface" /> <!-- The transmission that is used in the gazebo joints -->
+
+  <xacro:property name="arm_id" value="$(arg arm_id)" />
+  <xacro:property name="transmission" value="$(arg transmission)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
@@ -45,13 +46,13 @@
     </joint>
 
 
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint1" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint2" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint3" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint4" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint5" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint6" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="$(arg arm_id)_joint7" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="${arm_id}_joint1" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint2" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint3" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint4" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint5" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint6" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="${arm_id}_joint7" transmission="${transmission}" />
 
     <xacro:transmission-franka-state arm_id="$(arg arm_id)" />
     <xacro:transmission-franka-model arm_id="$(arg arm_id)"

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -4,10 +4,10 @@
   <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
   <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
   <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
-  <xacro:arg name="transmission" default="hardware_interface/EffortJointInterface" /> <!-- The transmission that is used in the gazebo joints -->
+  <!-- The transmission type that is used to control arm joints in gazebo: position, velocity, or effort -->
+  <xacro:arg name="transmission" default="effort" />
 
   <xacro:property name="arm_id" value="$(arg arm_id)" />
-  <xacro:property name="transmission" value="$(arg transmission)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
@@ -46,13 +46,20 @@
     </joint>
 
 
-    <xacro:gazebo-joint joint="${arm_id}_joint1" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint2" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint3" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint4" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint5" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint6" transmission="${transmission}" />
-    <xacro:gazebo-joint joint="${arm_id}_joint7" transmission="${transmission}" />
+    <xacro:property name="transmission" value="$(arg transmission)" />
+    <!-- sanity check -->
+    <xacro:if value="${transmission.lower() not in ['position', 'velocity', 'effort']}" >
+      ${xacro.fatal("transmission:=" + transmission + " is not one of position, velocity, or effort")}
+    </xacro:if>
+    <!-- Unify transmission argument into title case and expand to full name -->
+    <xacro:property name="transmission" value="hardware_interface/${transmission.title()}JointInterface" lazy_eval="false" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint1" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint2" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint3" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint4" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint5" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint6" transmission="${transmission}" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint7" transmission="${transmission}" />
 
     <xacro:transmission-franka-state arm_id="$(arg arm_id)" />
     <xacro:transmission-franka-model arm_id="$(arg arm_id)"

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -1,13 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
 
-  <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
-  <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
-  <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
+  <!-- Name of this panda -->
+  <xacro:arg name="arm_id" default="panda" />
+  <!-- Should a franka_gripper be mounted at the flange?" -->
+  <xacro:arg name="hand" default="false" />
+  <!-- Is the robot being simulated in gazebo?" -->
+  <xacro:arg name="gazebo" default="false" />
   <!-- The transmission type that is used to control arm joints in gazebo: position, velocity, or effort -->
   <xacro:arg name="transmission" default="effort" />
-
-  <xacro:property name="arm_id" value="$(arg arm_id)" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->

--- a/franka_gazebo/config/franka_hw_sim.yaml
+++ b/franka_gazebo/config/franka_hw_sim.yaml
@@ -11,3 +11,26 @@ franka_gripper:
 
   finger2:
     gains: { p: 100, i: 0, d: 1.0 }
+
+# Motion generators PID gains
+# NOTE: Needed since the gazebo_ros_control currently only directly support effort hardware
+# interfaces (see #161).
+motion_generators:
+  position:
+    gains:
+      panda_joint1: { p: 600, d: 30, i: 0 }
+      panda_joint2: { p: 600, d: 30, i: 0 }
+      panda_joint3: { p: 600, d: 30, i: 0 }
+      panda_joint4: { p: 600, d: 30, i: 0 }
+      panda_joint5: { p: 250, d: 10, i: 0 }
+      panda_joint6: { p: 150, d: 10, i: 0 }
+      panda_joint7: { p:  50, d:  5, i: 0 }
+  velocity:
+    gains:
+      panda_joint1: { p: 600, d: 30, i: 0 }
+      panda_joint2: { p: 600, d: 30, i: 0 }
+      panda_joint3: { p: 600, d: 30, i: 0 }
+      panda_joint4: { p: 600, d: 30, i: 0 }
+      panda_joint5: { p: 250, d: 10, i: 0 }
+      panda_joint6: { p: 150, d: 10, i: 0 }
+      panda_joint7: { p:  50, d:  5, i: 0 }

--- a/franka_gazebo/config/sim_controllers.yaml
+++ b/franka_gazebo/config/sim_controllers.yaml
@@ -66,3 +66,23 @@ effort_joint_trajectory_controller:
     $(arg arm_id)_joint5: { goal: 0.05 }
     $(arg arm_id)_joint6: { goal: 0.05 }
     $(arg arm_id)_joint7: { goal: 0.05 }
+
+position_joint_trajectory_controller:
+  type: position_controllers/JointTrajectoryController
+  joints:
+    - $(arg arm_id)_joint1
+    - $(arg arm_id)_joint2
+    - $(arg arm_id)_joint3
+    - $(arg arm_id)_joint4
+    - $(arg arm_id)_joint5
+    - $(arg arm_id)_joint6
+    - $(arg arm_id)_joint7
+  constraints:
+    goal_time: 0.5
+    $(arg arm_id)_joint1: { goal: 0.05}
+    $(arg arm_id)_joint2: { goal: 0.05}
+    $(arg arm_id)_joint3: { goal: 0.05}
+    $(arg arm_id)_joint4: { goal: 0.05}
+    $(arg arm_id)_joint5: { goal: 0.05}
+    $(arg arm_id)_joint6: { goal: 0.05}
+    $(arg arm_id)_joint7: { goal: 0.05}

--- a/franka_gazebo/include/franka_gazebo/franka_gripper_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_gripper_sim.h
@@ -136,5 +136,23 @@ class FrankaGripperSim
   void onMoveGoal(const franka_gripper::MoveGoalConstPtr& goal);
   void onGraspGoal(const franka_gripper::GraspGoalConstPtr& goal);
   void onGripperActionGoal(const control_msgs::GripperCommandGoalConstPtr& goal);
+
+  /**
+   * libfranka-like method to grasp an object with the gripper
+   * @param width Size of the object to grasp. [m]
+   * @param speed Closing speed. [m/s]
+   * @param force Grasping force. [N]
+   * @param epsilon Maximum tolerated deviation between the commanded width and the desired width
+   * @return True if the object could be grasped, false otherwise
+   */
+  bool grasp(double width, double speed, double force, franka_gripper::GraspEpsilon epsilon);
+
+  /**
+   * libfranka-like method to move the gripper to a certain position
+   * @param width Intended opening width. [m]
+   * @param speed Closing speed. [m/s]
+   * @return True if the command was successful, false otherwise.
+   */
+  bool move(double width, double speed);
 };
 }  // namespace franka_gazebo

--- a/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
@@ -115,6 +115,9 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
   ros::ServiceServer service_set_k_;
   ros::ServiceServer service_set_load_;
   ros::ServiceServer service_collision_behavior_;
+  ros::ServiceServer service_set_model_configuration_;
+
+  ros::ServiceClient gazebo_set_model_configuration_client_;
 
   std::vector<double> lower_force_thresholds_nominal_;
   std::vector<double> upper_force_thresholds_nominal_;

--- a/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <control_toolbox/pid.h>
 #include <franka/robot_state.h>
 #include <franka_gazebo/joint.h>
 #include <franka_hw/franka_model_interface.h>
@@ -31,6 +32,8 @@ const double kDefaultTauExtLowpassFilter = 1.0;  // no filtering per default of 
  * ### transmission_interface/SimpleTransmission
  * - hardware_interface/JointStateInterface
  * - hardware_interface/EffortJointInterface
+ * - hardware_interface/PositionJointInterface
+ * - hardware_interface/VelocityJointInterface
  *
  * ### franka_hw/FrankaStateInterface
  * ### franka_hw/FrankaModelInterface
@@ -101,8 +104,14 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
   gazebo::physics::ModelPtr robot_;
   std::map<std::string, std::shared_ptr<franka_gazebo::Joint>> joints_;
 
+  enum ControlMethod { EFFORT, POSITION, VELOCITY };
+  std::map<std::string, ControlMethod> joint_control_methods_;
+  std::map<std::string, control_toolbox::Pid> pid_controllers_;
+
   hardware_interface::JointStateInterface jsi_;
   hardware_interface::EffortJointInterface eji_;
+  hardware_interface::PositionJointInterface pji_;
+  hardware_interface::VelocityJointInterface vji_;
   franka_hw::FrankaStateInterface fsi_;
   franka_hw::FrankaModelInterface fmi_;
 
@@ -121,6 +130,8 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
 
   void initJointStateHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
   void initEffortCommandHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
+  void initPositionCommandHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
+  void initVelocityCommandHandle(const std::shared_ptr<franka_gazebo::Joint>& joint);
   void initFrankaStateHandle(const std::string& robot,
                              const urdf::Model& urdf,
                              const transmission_interface::TransmissionInfo& transmission);

--- a/franka_gazebo/include/franka_gazebo/joint.h
+++ b/franka_gazebo/include/franka_gazebo/joint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <angles/angles.h>
+#include <joint_limits_interface/joint_limits.h>
 #include <ros/ros.h>
 #include <Eigen/Dense>
 #include <gazebo/physics/Joint.hh>
@@ -34,6 +35,10 @@ struct Joint {
   /// The type of joint, i.e. revolute, prismatic, ... @see
   /// http://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1Joint.html
   int type;
+
+  /// Joint limits @see
+  /// https://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1JointLimits.html
+  joint_limits_interface::JointLimits limits;
 
   /// The axis of rotation/translation of this joint in local coordinates
   Eigen::Vector3d axis;

--- a/franka_gazebo/include/franka_gazebo/joint.h
+++ b/franka_gazebo/include/franka_gazebo/joint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <angles/angles.h>
+#include <joint_limits_interface/joint_limits.h>
 #include <ros/ros.h>
 #include <Eigen/Dense>
 #include <gazebo/physics/Joint.hh>
@@ -35,12 +36,21 @@ struct Joint {
   /// http://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1Joint.html
   int type;
 
+  /// Joint limits @see
+  /// https://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1JointLimits.html
+  joint_limits_interface::JointLimits limits;
+
   /// The axis of rotation/translation of this joint in local coordinates
   Eigen::Vector3d axis;
 
   /// The currently applied command from a controller acting on this joint either in \f$N\f$ or
   /// \f$Nm\f$ without gravity
   double command = 0;
+
+  /// The currently CLAMPED applied command from the controller acting on this joint either in \f$N\f$ or
+  /// \f$Nm\f$ without gravity.
+  /// NOTE: Clamped to zero when the joint is in its limits.
+  double clamped_command = 0;
 
   /// The currently acting gravity force or torque acting on this joint in \f$N\f$ or \f$Nm\f$
   double gravity = 0;

--- a/franka_gazebo/include/franka_gazebo/joint.h
+++ b/franka_gazebo/include/franka_gazebo/joint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <angles/angles.h>
+#include <joint_limits_interface/joint_limits.h>
 #include <ros/ros.h>
 #include <Eigen/Dense>
 #include <gazebo/physics/Joint.hh>
@@ -34,6 +35,10 @@ struct Joint {
   /// The type of joint, i.e. revolute, prismatic, ... @see
   /// http://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1Joint.html
   int type;
+
+  /// Joint limits @see
+  /// https://docs.ros.org/en/diamondback/api/urdf/html/classurdf_1_1JointLimits.html
+  joint_limits_interface::JointLimits limits;
 
   /// The axis of rotation/translation of this joint in local coordinates
   Eigen::Vector3d axis;
@@ -87,9 +92,18 @@ struct Joint {
    */
   bool isInCollision() const;
 
+  /**
+   * Sets the joint position.
+   */
+  void setJointPosition(const double joint_position);
+
  private:
   double lastVelocity = std::numeric_limits<double>::quiet_NaN();
   double lastAcceleration = std::numeric_limits<double>::quiet_NaN();
+
+  // Used to track whether the user requested a joint position to be set.
+  bool setPositionRequested_ = false;
+  double requestedPosition_ = 0.0;
 };
 
 }  // namespace franka_gazebo

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -7,6 +7,7 @@
   <arg name="paused"      default="false" doc="Should the simulation directly be stopped at 0s?" />
   <arg name="world"       default="worlds/empty.world" doc="Filename to a SDF World for gazebo to use" />
   <arg name="rviz"        default="false" doc="Should RVIz be launched?" />
+  <arg name="physics"     default="dart"   doc="The physics engine used by gazebo"/> <!--Phyics engines: dart|ode-->
 
   <!-- Robot Customization -->
   <arg name="arm_id"      default="panda" doc="Name of the panda robot to spawn" />
@@ -37,6 +38,7 @@
     <arg name="paused" value="true"/>
     <arg name="gui" value="$(eval not arg('headless'))"/>
     <arg name="use_sim_time" value="true"/>
+    <arg name="physics" value="$(arg physics)"/>
   </include>
 
   <param name="robot_description"

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -11,8 +11,8 @@
   <!-- Robot Customization -->
   <arg name="arm_id"      default="panda" doc="Name of the panda robot to spawn" />
   <arg name="use_gripper" default="true"  doc="Should a franka hand be mounted on the flange?" />
-  <arg name="transmission" default="effort" doc="Transmission type used for arm joints. One of position, velocity, effort." />
   <arg name="controller"  default=" "     doc="Which example controller should be started? (One of {cartesian_impedance,model,force}_example_controller)" />
+  <arg name="transmission" default="effort" doc="Transmission type used for arm joints. One of position, velocity, effort." />
   <arg name="x"           default="0"     doc="How far forward to place the base of the robot in [m]?" />
   <arg name="y"           default="0"     doc="How far leftwards to place the base of the robot in [m]?" />
   <arg name="z"           default="0"     doc="How far upwards to place the base of the robot in [m]?" />

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -11,6 +11,7 @@
   <!-- Robot Customization -->
   <arg name="arm_id"      default="panda" doc="Name of the panda robot to spawn" />
   <arg name="use_gripper" default="true"  doc="Should a franka hand be mounted on the flange?" />
+  <arg name="transmission" default="effort" doc="Transmission type used for arm joints. One of position, velocity, effort." />
   <arg name="controller"  default=" "     doc="Which example controller should be started? (One of {cartesian_impedance,model,force}_example_controller)" />
   <arg name="x"           default="0"     doc="How far forward to place the base of the robot in [m]?" />
   <arg name="y"           default="0"     doc="How far leftwards to place the base of the robot in [m]?" />
@@ -43,6 +44,7 @@
          command="xacro $(find franka_description)/robots/panda_arm.urdf.xacro
                   gazebo:=true
                   hand:=$(arg use_gripper)
+                  transmission:=$(arg transmission)
                   arm_id:=$(arg arm_id)
                   xyz:='$(arg x) $(arg y) $(arg z)'
                   rpy:='$(arg roll) $(arg pitch) $(arg yaw)'">

--- a/franka_gazebo/src/franka_gripper_sim.cpp
+++ b/franka_gazebo/src/franka_gripper_sim.cpp
@@ -336,15 +336,7 @@ void FrankaGripperSim::onMoveGoal(const franka_gripper::MoveGoalConstPtr& goal) 
     interrupt("Command interrupted, because new move action called", State::MOVING);
   }
 
-  franka_gripper::GraspEpsilon eps;
-  eps.inner = this->tolerance_move_;
-  eps.outer = this->tolerance_move_;
-  transition(State::MOVING, Config{.width_desired = goal->width,
-                                   .speed_desired = goal->speed,
-                                   .force_desired = 0,
-                                   .tolerance = eps});
-
-  waitUntilStateChange();
+  bool move_succeeded = move(goal->width, goal->speed);
 
   if (not this->action_move_->isActive()) {
     // Move Action was interrupted from another action goal callback and already preempted.
@@ -353,15 +345,14 @@ void FrankaGripperSim::onMoveGoal(const franka_gripper::MoveGoalConstPtr& goal) 
   }
 
   franka_gripper::MoveResult result;
-  if (this->state_ != State::IDLE) {
+  if (not move_succeeded) {
     result.success = static_cast<decltype(result.success)>(false);
     result.error = "Unexpected state transistion: The gripper not in IDLE as expected";
     action_move_->setAborted(result, result.error);
     return;
   }
-  double width = this->finger1_.getPosition() + this->finger2_.getPosition();  // recalculate
-  bool ok = goal->width - eps.inner < width and width < goal->width + eps.outer;
-  result.success = static_cast<decltype(result.success)>(ok);
+
+  result.success = static_cast<decltype(result.success)>(true);
   action_move_->setSucceeded(result);
 }
 
@@ -389,14 +380,7 @@ void FrankaGripperSim::onGraspGoal(const franka_gripper::GraspGoalConstPtr& goal
     interrupt("Command interrupted, because new grasp action called", State::GRASPING);
   }
 
-  double width = this->finger1_.getPosition() + this->finger2_.getPosition();
-  float direction = std::copysign(1.0, goal->width - width);
-  transition(State::GRASPING, Config{.width_desired = goal->width < width ? 0 : kMaxFingerWidth,
-                                     .speed_desired = goal->speed,
-                                     .force_desired = direction * goal->force,
-                                     .tolerance = goal->epsilon});
-
-  waitUntilStateChange();
+  bool grasp_succeeded = grasp(goal->width, goal->speed, goal->force, goal->epsilon);
 
   if (not this->action_grasp_->isActive()) {
     // Grasping Action was interrupted from another action goal callback and already preempted.
@@ -412,15 +396,15 @@ void FrankaGripperSim::onGraspGoal(const franka_gripper::GraspGoalConstPtr& goal
     return;
   }
 
-  width = this->finger1_.getPosition() + this->finger2_.getPosition();  // recalculate
-  bool ok = goal->width - goal->epsilon.inner < width and width < goal->width + goal->epsilon.outer;
-  result.success = static_cast<decltype(result.success)>(ok);
-  if (not ok) {
-    result.error = "When the gripper stopped (below speed of " +
-                   std::to_string(this->speed_threshold_) +
-                   " m/s the width between the fingers was not at " + std::to_string(goal->width) +
-                   "m (-" + std::to_string(goal->epsilon.inner) + "m/+" +
-                   std::to_string(goal->epsilon.outer) + "m) but at " + std::to_string(width) + "m";
+  result.success = static_cast<decltype(result.success)>(grasp_succeeded);
+  if (not grasp_succeeded) {
+    double current_width = this->finger1_.getPosition() + this->finger2_.getPosition();
+    result.error =
+        "When the gripper stopped (below speed of " + std::to_string(this->speed_threshold_) +
+        " m/s the width between the fingers was not at " + std::to_string(goal->width) + "m (-" +
+        std::to_string(goal->epsilon.inner) + "m/+" + std::to_string(goal->epsilon.outer) +
+        "m) but at " + std::to_string(current_width) + "m";
+    action_grasp_->setAborted(result, result.error);
     setState(State::IDLE);
   }
 
@@ -428,52 +412,91 @@ void FrankaGripperSim::onGraspGoal(const franka_gripper::GraspGoalConstPtr& goal
 }
 
 void FrankaGripperSim::onGripperActionGoal(const control_msgs::GripperCommandGoalConstPtr& goal) {
-  ROS_INFO_STREAM_NAMED("FrankaGripperSim", "New Gripper Command Action Goal received: "
-                                                << goal->command.max_effort << "N");
-
+  control_msgs::GripperCommandResult result;
   // HACK: As one gripper finger is <mimic>, MoveIt!'s trajectory execution manager
   // only sends us the width of one finger. Multiply by 2 to get the intended width.
-  double width = this->finger1_.getPosition() + this->finger2_.getPosition();
+  double width_d = goal->command.position * 2.0;
+
+  ROS_INFO_STREAM_NAMED("FrankaGripperSim", "New Gripper Command Action Goal received: "
+                                                << width_d << "m, " << goal->command.max_effort
+                                                << "N");
+
+  if (width_d > kMaxFingerWidth || width_d < 0.0) {
+    std::string error =
+        "Commanding out of range width! max_width = " + std::to_string(kMaxFingerWidth) +
+        " command = " + std::to_string(width_d);
+    ROS_ERROR_STREAM_NAMED("FrankaGripperSim", error);
+    result.reached_goal = static_cast<decltype(result.reached_goal)>(false);
+    action_gc_->setAborted(result, error);
+    return;
+  }
 
   franka_gripper::GraspEpsilon eps;
   eps.inner = this->tolerance_gripper_action_;
   eps.outer = this->tolerance_gripper_action_;
 
-  transition(State::GRASPING,
-             Config{.width_desired = goal->command.position * 2.0 < width ? 0 : kMaxFingerWidth,
-                    .speed_desired = this->speed_default_,
-                    .force_desired = goal->command.max_effort,
-                    .tolerance = eps});
+  double current_width = this->finger1_.getPosition() + this->finger2_.getPosition();
+  constexpr double kMinimumGraspForce = 1e-4;
+  bool succeeded;
 
-  waitUntilStateChange();
-
-  if (not this->action_gc_->isActive()) {
-    // Gripper Action was interrupted from another action goal callback and already preempted.
-    // Don't try to resend result now
-    return;
+  if (std::abs(goal->command.max_effort) < kMinimumGraspForce or width_d > current_width) {
+    succeeded = move(width_d, this->speed_default_);
+    if (not this->action_gc_->isActive()) {
+      // Gripper Action was interrupted from another action goal callback and already preempted.
+      // Don't try to resend result now
+      return;
+    }
+  } else {
+    succeeded = grasp(width_d, this->speed_default_, goal->command.max_effort, eps);
+    if (not this->action_gc_->isActive()) {
+      // Gripper Action was interrupted from another action goal callback and already preempted.
+      // Don't try to resend result now
+      return;
+    }
+    if (this->state_ != State::HOLDING) {
+      result.reached_goal = static_cast<decltype(result.reached_goal)>(false);
+      std::string error = "Unexpected state transition: The gripper not in HOLDING as expected";
+      action_gc_->setAborted(result, error);
+      return;
+    }
   }
 
-  control_msgs::GripperCommandResult result;
-  if (this->state_ != State::HOLDING) {
-    result.reached_goal = static_cast<decltype(result.reached_goal)>(false);
-    std::string error = "Unexpected state transistion: The gripper not in HOLDING as expected";
-    action_gc_->setAborted(result, error);
-    return;
-  }
-
-  double width_d = goal->command.position * 2.0;
-  width = this->finger1_.getPosition() + this->finger2_.getPosition();  // recalculate
-  bool inside_tolerance = width_d - this->tolerance_gripper_action_ < width and
-                          width < width_d + this->tolerance_gripper_action_;
-  result.position = width;
+  result.position = this->finger1_.getPosition() + this->finger2_.getPosition();
   result.effort = 0;
   result.stalled = static_cast<decltype(result.stalled)>(false);
-  result.reached_goal = static_cast<decltype(result.reached_goal)>(inside_tolerance);
-  if (not inside_tolerance) {
-    std::lock_guard<std::mutex> lock(this->mutex_);
-    this->state_ = State::IDLE;
+  result.reached_goal = static_cast<decltype(result.reached_goal)>(succeeded);
+  if (not succeeded) {
+    setState(State::IDLE);
   }
   action_gc_->setSucceeded(result);
+}
+
+bool FrankaGripperSim::move(double width, double speed) {
+  franka_gripper::GraspEpsilon eps;
+  eps.inner = this->tolerance_move_;
+  eps.outer = this->tolerance_move_;
+  transition(
+      State::MOVING,
+      Config{.width_desired = width, .speed_desired = speed, .force_desired = 0, .tolerance = eps});
+
+  waitUntilStateChange();
+  return this->state_ == State::IDLE;
+}
+
+bool FrankaGripperSim::grasp(double width,
+                             double speed,
+                             double force,
+                             franka_gripper::GraspEpsilon epsilon) {
+  double current_width = this->finger1_.getPosition() + this->finger2_.getPosition();
+  float direction = std::copysign(1.0, width - current_width);
+  transition(State::GRASPING, Config{.width_desired = width < current_width ? 0 : kMaxFingerWidth,
+                                     .speed_desired = speed,
+                                     .force_desired = direction * force,
+                                     .tolerance = epsilon});
+
+  waitUntilStateChange();
+  current_width = this->finger1_.getPosition() + this->finger2_.getPosition();  // recalculate
+  return width - epsilon.inner < current_width and current_width < width + epsilon.outer;
 }
 
 }  // namespace franka_gazebo

--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -40,7 +40,16 @@ bool FrankaHWSim::initSim(const std::string& robot_namespace,
   gazebo::physics::PhysicsEnginePtr physics = gazebo::physics::get_world()->GetPhysicsEngine();
 #endif
 
+  // Print information about the used physics engine
+  std::vector<std::string> supported_engines{"ode", "dart"};
+  std::string physics_engine = physics->GetType();
   ROS_INFO_STREAM_NAMED("franka_hw_sim", "Using physics type " << physics->GetType());
+  if (std::find(supported_engines.begin(), supported_engines.end(), physics_engine) ==
+      supported_engines.end()) {
+    ROS_ERROR_STREAM_NAMED("franka_hw_sim",
+                           "The Panda Gazebo model does not yet officially support the '" +
+                               physics_engine + "' physics engine.");
+  }
 
   // Retrieve initial gravity vector from Gazebo
   // NOTE: Can be overwritten by the user via the 'gravity_vector' ROS parameter.

--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -7,13 +7,18 @@
 #include <franka_hw/services.h>
 #include <franka_msgs/SetEEFrame.h>
 #include <franka_msgs/SetForceTorqueCollisionBehavior.h>
+#include <franka_msgs/SetJointConfiguration.h>
 #include <franka_msgs/SetKFrame.h>
 #include <franka_msgs/SetLoad.h>
+#include <gazebo_msgs/SetModelConfiguration.h>
 #include <gazebo_ros_control/robot_hw_sim.h>
+#include <joint_limits_interface/joint_limits_urdf.h>
 #include <Eigen/Dense>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <boost/algorithm/clamp.hpp>
+#include "ros/ros.h"
 
 namespace franka_gazebo {
 
@@ -85,6 +90,7 @@ bool FrankaHWSim::initSim(const std::string& robot_namespace,
       return false;
     }
     joint->type = urdf_joint->type;
+    joint_limits_interface::getJointLimits(urdf_joint, joint->limits);
     joint->axis = Eigen::Vector3d(urdf_joint->axis.x, urdf_joint->axis.y, urdf_joint->axis.z);
 
     // Get a handle to the underlying Gazebo Joint
@@ -159,6 +165,10 @@ bool FrankaHWSim::initSim(const std::string& robot_namespace,
 
   // Initialize ROS Services
   initServices(model_nh);
+
+  // Connect to '/gazebo/set_model_configuration' service
+  this->gazebo_set_model_configuration_client_ =
+      model_nh.serviceClient<gazebo_msgs::SetModelConfiguration>("/gazebo/set_model_configuration");
 
   return readParameters(model_nh, *urdf);
 }
@@ -304,6 +314,109 @@ void FrankaHWSim::initServices(ros::NodeHandle& nh) {
 
             response.success = true;
             return true;
+          });
+  this->service_set_model_configuration_ =
+      franka_hw::advertiseService<franka_msgs::SetJointConfiguration>(
+          nh, "set_franka_model_configuration", [&](auto& request, auto& response) {
+            // Check if positions equals the number of joints
+            if (request.configuration.name.size() == 1 && request.configuration.name[0].empty()) {
+              ROS_ERROR_STREAM_NAMED("franka_hw_sim",
+                                     "Setting of Franka model configuration failed since "
+                                     "no joints were specified in the request.");
+              response.success = false;
+              response.error = "no joints specified";
+              return false;
+            }
+            if (request.configuration.name.size() != request.configuration.position.size()) {
+              ROS_ERROR_STREAM_NAMED("franka_hw_sim",
+                                     "Setting of Franka model configuration failed since "
+                                     "the 'position' and 'name' fields were of unequal length.");
+              response.success = false;
+              response.error = "'position' and 'name' fields length unequal";
+              return false;
+            }
+
+            // Print request information
+            std::string requested_configuration_string;
+            for (int ii = 0; ii < request.configuration.name.size(); ii++) {
+                requested_configuration_string += request.configuration.name[ii] + ": " + std::to_string(request.configuration.position[ii])  + ", ";
+            }
+            requested_configuration_string = requested_configuration_string.substr(0, requested_configuration_string.length() - 2); //Remove last 2 characters
+            ROS_INFO_STREAM_NAMED("franka_hw_sim", "Setting joint configuration: " << requested_configuration_string);
+
+            // Validate joint names and joint limits
+            std::map<std::string, double> model_configuration;
+            for (int ii = 0; ii < request.configuration.name.size(); ii++) {
+              std::string joint(request.configuration.name[ii]);
+              double position(request.configuration.position[ii]);
+
+              if (this->joints_.find(joint) != this->joints_.end()) { // If joint exists
+                double min_position(this->joints_[joint]->limits.min_position);
+                double max_position(this->joints_[joint]->limits.max_position);
+
+                // Check if position is within joint limits
+                if (position == boost::algorithm::clamp(position, min_position, max_position)) {
+                  model_configuration.emplace(std::make_pair(joint, position));
+                } else {
+                  ROS_WARN_STREAM_NAMED("franka_hw_sim",
+                                        "Joint configuration of joint '"
+                                            << joint << "' was not set since the requested joint position ("
+                                            << position << ") is not within joint limits (i.e. "
+                                            << min_position << " - " << max_position << ").");
+                }
+              } else {
+                ROS_WARN_STREAM_NAMED("franka_hw_sim",
+                                      "Joint configuration of joint '"
+                                          << joint
+                                          << "' not set since it is not a valid panda joint.");
+              }
+            }
+
+            // Return if no valid positions were found
+            if (model_configuration.size() == 0){
+              ROS_ERROR_STREAM_NAMED("franka_hw_sim",
+                        "Setting of Franka model configuration aborted since no valid "
+                        "joint configuration were found.");
+              response.success = false;
+              response.error = "no valid joint configurations";
+              return false;
+            }
+
+            // Throw warnings about unused request fields
+            if (request.configuration.effort.size() != 0) {
+              ROS_WARN_STREAM_ONCE_NAMED("franka_hw_sim",
+                                    "The 'set_franka_model_configuration' service does not use the "
+                                    "'effort' field.");
+            }
+            if (request.configuration.velocity.size() != 0) {
+              ROS_WARN_STREAM_ONCE_NAMED("franka_hw_sim",
+                                    "The 'set_franka_model_configuration' service does not use the "
+                                    "'velocity' field.");
+            }
+
+            // Call Gazebo 'set_model_configuration' service and update Franka joint positions
+            gazebo_msgs::SetModelConfiguration gazebo_model_configuration;
+            gazebo_model_configuration.request.model_name = "panda";
+            for (const auto& pair : model_configuration) {
+              gazebo_model_configuration.request.joint_names.push_back(pair.first);
+              gazebo_model_configuration.request.joint_positions.push_back(pair.second);
+            }
+            if (this->gazebo_set_model_configuration_client_.call(gazebo_model_configuration)) {
+              // Update franka positions
+              for (const auto& pair : model_configuration) {
+                this->joints_[pair.first]->setJointPosition(pair.second);
+              }
+
+              response.success = true;
+              return true;
+            } else {
+              ROS_WARN_STREAM_NAMED(
+                  "franka_hw_sim",
+                  "Setting of Franka model configuration failed since "
+                  "a problem occurred when setting the joint configuration in Gazebo.");
+              response.success = false;
+              return false;
+            }
           });
 }
 

--- a/franka_gazebo/src/joint.cpp
+++ b/franka_gazebo/src/joint.cpp
@@ -50,6 +50,13 @@ void Joint::update(const ros::Duration& dt) {
   }
   this->jerk = (this->acceleration - this->lastAcceleration) / dt.toSec();
   this->lastAcceleration = this->acceleration;
+
+  // Store the clamped command
+  // NOTE: Clamped to zero when joint is in its joint limits.
+  this->clamped_command =
+      (this->position > this->limits.min_position && this->position < this->limits.max_position)
+          ? this->command
+          : 0.0;
 }
 
 double Joint::getLinkMass() const {
@@ -64,10 +71,10 @@ double Joint::getLinkMass() const {
 }
 
 bool Joint::isInCollision() const {
-  return std::abs(this->effort - this->command) > this->collision_threshold;
+  return std::abs(this->effort - this->clamped_command + this->gravity) > this->collision_threshold;
 }
 
 bool Joint::isInContact() const {
-  return std::abs(this->effort - this->command) > this->contact_threshold;
+  return std::abs(this->effort - this->clamped_command + this->gravity) > this->contact_threshold;
 }
 }  // namespace franka_gazebo

--- a/franka_gazebo/src/joint.cpp
+++ b/franka_gazebo/src/joint.cpp
@@ -9,6 +9,13 @@ void Joint::update(const ros::Duration& dt) {
     return;
   }
 
+  // Set joint position to requested joint position
+  // NOTE: Implemented like this to prevent racing conditions.
+  if (this->setPositionRequested_) {
+    this->position = this->requestedPosition_;
+    this->setPositionRequested_ = false;
+  }
+
   this->velocity = this->handle->GetVelocity(0);
 #if GAZEBO_MAJOR_VERSION >= 8
   double position = this->handle->Position(0);
@@ -70,4 +77,10 @@ bool Joint::isInCollision() const {
 bool Joint::isInContact() const {
   return std::abs(this->effort - this->command) > this->contact_threshold;
 }
+
+void Joint::setJointPosition(const double joint_position) {
+  this->requestedPosition_ = joint_position;
+  this->setPositionRequested_ = true;
+}
+
 }  // namespace franka_gazebo

--- a/franka_gripper/src/franka_gripper.cpp
+++ b/franka_gripper/src/franka_gripper.cpp
@@ -48,7 +48,8 @@ void gripperCommandExecuteCallback(
     if (std::abs(target_width - state.width) < kSamePositionThreshold) {
       return true;
     }
-    if (target_width >= state.width) {
+    constexpr double kMinimumGraspForce = 1e-4;
+    if (std::abs(goal->command.max_effort) < kMinimumGraspForce or target_width >= state.width) {
       return gripper.move(target_width, default_speed);
     }
     return gripper.grasp(target_width, default_speed, goal->command.max_effort, grasp_epsilon.inner,

--- a/franka_msgs/CMakeLists.txt
+++ b/franka_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(franka_msgs)
 
-find_package(catkin REQUIRED COMPONENTS message_generation std_msgs actionlib_msgs)
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs sensor_msgs actionlib_msgs)
 
 add_message_files(FILES Errors.msg FrankaState.msg)
 
@@ -10,6 +10,7 @@ add_service_files(FILES
   SetEEFrame.srv
   SetForceTorqueCollisionBehavior.srv
   SetFullCollisionBehavior.srv
+  SetJointConfiguration.srv
   SetJointImpedance.srv
   SetKFrame.srv
   SetLoad.srv
@@ -17,6 +18,6 @@ add_service_files(FILES
 
 add_action_files(FILES ErrorRecovery.action)
 
-generate_messages(DEPENDENCIES std_msgs actionlib_msgs)
+generate_messages(DEPENDENCIES std_msgs sensor_msgs actionlib_msgs)
 
-catkin_package(CATKIN_DEPENDS message_runtime std_msgs actionlib_msgs)
+catkin_package(CATKIN_DEPENDS message_runtime std_msgs sensor_msgs actionlib_msgs)

--- a/franka_msgs/package.xml
+++ b/franka_msgs/package.xml
@@ -16,6 +16,7 @@
   <build_depend>message_generation</build_depend>
 
   <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>actionlib_msgs</depend>
 
   <exec_depend>message_runtime</exec_depend>

--- a/franka_msgs/srv/SetJointConfiguration.srv
+++ b/franka_msgs/srv/SetJointConfiguration.srv
@@ -1,0 +1,4 @@
+sensor_msgs/JointState configuration
+---
+bool success
+string error


### PR DESCRIPTION
This pull request updates the actions/checkout action to v3 since v2 uses node12, which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
