### PR TITLE
ci: update checkout action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         mkdir -p ${{github.workspace}}/devel     # compilation cache for formatter & linter
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/franka_ros
 


### PR DESCRIPTION
This pull request updates the actions/checkout action to v3 since v2 uses node12
which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/. 

@Maverobot, @gollth I think this small update can be directly merged.

