### PR TITLE
fix(franka_hw_sim): fix robot name differ warning

### DIFF
--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -36,7 +36,7 @@ bool FrankaHWSim::initSim(const std::string& robot_namespace,
                           const urdf::Model* const urdf,
                           std::vector<transmission_interface::TransmissionInfo> transmissions) {
   model_nh.param<std::string>("arm_id", this->arm_id_, robot_namespace);
-  if (this->arm_id_ != robot_namespace) {
+  if (robot_namespace != "/" && this->arm_id_ != robot_namespace) {
     ROS_WARN_STREAM_NAMED(
         "franka_hw_sim",
         "Caution: Robot names differ! Read 'arm_id: "


### PR DESCRIPTION
This pull request ensures that the `Caution: Robot Names differ!` warning is not thrown when the user omits the `<robotNamespace>` tag in their URDF/SDF file.
