### PR TITLE
refactor(franka_gazebo): remove FrankaHWSim robot namespace warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_description`: `<xacro:franka_robot/>` macro now supports to customize the `parent` frame and its `xyz` + `rpy` offset
   * `franka_hw`: Fix the bug where the previous controller is still running after switching the controller. ([#326](https://github.com/frankaemika/franka_ros/issues/326))
   * `franka_gazebo`: Add `set_franka_model_configuration` service.
+  * `franka_gazebo`: remove FrankaHWSim robot namespace warning
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_gazebo/src/franka_hw_sim.cpp
+++ b/franka_gazebo/src/franka_hw_sim.cpp
@@ -35,14 +35,14 @@ bool FrankaHWSim::initSim(const std::string& robot_namespace,
                           gazebo::physics::ModelPtr parent,
                           const urdf::Model* const urdf,
                           std::vector<transmission_interface::TransmissionInfo> transmissions) {
-  model_nh.param<std::string>("arm_id", this->arm_id_, robot_namespace);
-  if (this->arm_id_ != robot_namespace) {
-    ROS_WARN_STREAM_NAMED(
-        "franka_hw_sim",
-        "Caution: Robot names differ! Read 'arm_id: "
-            << this->arm_id_ << "' from parameter server but URDF defines '<robotNamespace>"
-            << robot_namespace << "</robotNamespace>'. Will use '" << this->arm_id_ << "'!");
+  // Try to get the arm_id from the robot_namespace otherwise use the model name.
+  if (!model_nh.hasParam("arm_id")) {
+    ROS_WARN_STREAM_NAMED("franka_hw_sim", "No 'arm_id' found on '" << model_nh.getNamespace()
+                                                                    << "' parameter namespace."
+                                                                    << " Using model name instead ("
+                                                                    << parent->GetName() << ").");
   }
+  model_nh.param<std::string>("arm_id", this->arm_id_, parent->GetName());
 
   this->robot_ = parent;
   this->robot_initialized_ = false;


### PR DESCRIPTION
In commit f2f82b2e4c3279d7196d1836049d649bd4252fb3, a robot namespace warning was introduced in the FrankaHWSim package. This warning was added to address a specific issue at the time (see https://github.com/frankaemika/franka_ros/pull/187#issuecomment-963242982). However, with the recent merge of PR #196, the conditions that necessitated this warning are no longer applicable.

To enhance the user experience and ensure clarity in error messages, I propose the following changes:

 - **Remove Redundant Robot Namespace Warning:** The warning introduced in f2f82b2e4c3279d7196d1836049d649bd4252fb3 is no longer needed since this warning only would be printed if the URDF is found. The URDF will only be found when the user specifies the correct robot namespace.
 
- **Change arm_id default value:** In the original code, the `robot_namespace` was used as the default value for the `arm_id` attribute. This could trigger cryptic hardware transmission warnings if users forget to set the `arm_id` parameter on the `robot_namespace`. This can be solved by replacing the default `robot_namespace` with the model name as the default value for the `arm_id` attribute.

- Introduce a warning mechanism that notifies users when they fail to load the arm_id parameter within the model parameter namespace. This will help users identify and resolve namespace-related issues more effectively.

Please let me know if you have any questions about my pull request.