### PR TITLE
Remove enforcement of C++14 standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         mkdir -p ${{github.workspace}}/devel     # compilation cache for formatter & linter
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src/franka_ros
 
@@ -35,7 +35,7 @@ jobs:
 
     - name: Build Docker Image
       if:   github.ref == 'refs/heads/develop' || ${{env.FLAVOR == matrix.ros_distro}}
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         tags: franka_ros:${{matrix.ros_distro}}
         file: .ci/Dockerfile.${{matrix.ros_distro}}
@@ -74,7 +74,7 @@ jobs:
         run: |
           source /ros/devel/setup.bash
           cmake --build /ros/build --target check-format
-    
+
     - name: Check Python Format
       if:   github.ref == 'refs/heads/develop' || ${{env.FLAVOR == matrix.ros_distro}}
       uses: addnab/docker-run-action@v3
@@ -111,7 +111,7 @@ jobs:
           catkin_test_results
 
     - name: Upload Tests to Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if:   github.ref == 'refs/heads/develop' || ${{env.FLAVOR == matrix.ros_distro}}
       with:
         name: test-results

--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(franka_control)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
   controller_manager

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.4)
 project(franka_example_controllers)
 
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(catkin REQUIRED COMPONENTS
   controller_interface

--- a/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
@@ -10,7 +10,8 @@
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 
-using namespace boost::placeholders;
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 #include <franka_example_controllers/pseudo_inversion.h>
 

--- a/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
@@ -10,6 +10,8 @@
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 
+using namespace boost::placeholders;
+
 #include <franka_example_controllers/pseudo_inversion.h>
 
 namespace franka_example_controllers {

--- a/franka_example_controllers/src/dual_arm_cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/dual_arm_cartesian_impedance_example_controller.cpp
@@ -18,6 +18,8 @@
 #include <tf/transform_listener.h>
 #include <tf_conversions/tf_eigen.h>
 
+using namespace boost::placeholders;
+
 namespace franka_example_controllers {
 
 bool DualArmCartesianImpedanceExampleController::initArm(

--- a/franka_example_controllers/src/dual_arm_cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/dual_arm_cartesian_impedance_example_controller.cpp
@@ -18,7 +18,8 @@
 #include <tf/transform_listener.h>
 #include <tf_conversions/tf_eigen.h>
 
-using namespace boost::placeholders;
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 namespace franka_example_controllers {
 

--- a/franka_example_controllers/src/force_example_controller.cpp
+++ b/franka_example_controllers/src/force_example_controller.cpp
@@ -11,6 +11,8 @@
 
 #include <franka/robot_state.h>
 
+using namespace boost::placeholders;
+
 namespace franka_example_controllers {
 
 bool ForceExampleController::init(hardware_interface::RobotHW* robot_hw,

--- a/franka_example_controllers/src/force_example_controller.cpp
+++ b/franka_example_controllers/src/force_example_controller.cpp
@@ -11,7 +11,8 @@
 
 #include <franka/robot_state.h>
 
-using namespace boost::placeholders;
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 namespace franka_example_controllers {
 

--- a/franka_example_controllers/src/teleop_gripper_node.cpp
+++ b/franka_example_controllers/src/teleop_gripper_node.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <mutex>
 
+using namespace boost::placeholders;
+
 using franka_gripper::GraspAction;
 using franka_gripper::HomingAction;
 using franka_gripper::MoveAction;

--- a/franka_example_controllers/src/teleop_gripper_node.cpp
+++ b/franka_example_controllers/src/teleop_gripper_node.cpp
@@ -17,7 +17,8 @@
 #include <memory>
 #include <mutex>
 
-using namespace boost::placeholders;
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 using franka_gripper::GraspAction;
 using franka_gripper::HomingAction;

--- a/franka_example_controllers/src/teleop_joint_pd_example_controller.cpp
+++ b/franka_example_controllers/src/teleop_joint_pd_example_controller.cpp
@@ -17,7 +17,8 @@
 #include <vector>
 
 using Vector7d = Eigen::Matrix<double, 7, 1>;
-using namespace boost::placeholders;
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 const std::string kControllerName = "TeleopJointPDExampleController";
 

--- a/franka_example_controllers/src/teleop_joint_pd_example_controller.cpp
+++ b/franka_example_controllers/src/teleop_joint_pd_example_controller.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 using Vector7d = Eigen::Matrix<double, 7, 1>;
+using namespace boost::placeholders;
 
 const std::string kControllerName = "TeleopJointPDExampleController";
 

--- a/franka_gazebo/CMakeLists.txt
+++ b/franka_gazebo/CMakeLists.txt
@@ -11,9 +11,6 @@ if(${ARCHITECTURE} STREQUAL "armv7l")
 endif()
 
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   gazebo_dev

--- a/franka_gazebo/src/franka_gripper_sim.cpp
+++ b/franka_gazebo/src/franka_gripper_sim.cpp
@@ -4,7 +4,7 @@
 #include <franka_gazebo/franka_gripper_sim.h>
 #include <pluginlib/class_list_macros.h>
 
-using namespace boost::placeholders;
+using boost::placeholders::_1;
 
 namespace franka_gazebo {
 

--- a/franka_gazebo/src/franka_gripper_sim.cpp
+++ b/franka_gazebo/src/franka_gripper_sim.cpp
@@ -4,6 +4,8 @@
 #include <franka_gazebo/franka_gripper_sim.h>
 #include <pluginlib/class_list_macros.h>
 
+using namespace boost::placeholders;
+
 namespace franka_gazebo {
 
 using actionlib::SimpleActionServer;

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(franka_gripper)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   message_generation

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(franka_hw)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   controller_interface

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -111,6 +111,9 @@ install(TARGETS franka_hw franka_control_services
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
+install(FILES franka_combinable_hw_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 ## Tools
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/ClangTools.cmake OPTIONAL

--- a/franka_hw/include/franka_hw/resource_helpers.h
+++ b/franka_hw/include/franka_hw/resource_helpers.h
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache-2.0 license, see LICENSE
 #pragma once
 
+#include <stdint.h>
 #include <list>
 #include <map>
 #include <string>

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(franka_visualization)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   roscpp


### PR DESCRIPTION
Remove enforcement of C++14 standard. Modern defaults are:
- C++14 on Ubuntu 20.04 / gcc 9.4
- C++17 on Ubuntu 22.04 / gcc 11.4

Thus, C++14 is satisfied automatically on these systems.
However, on Ubuntu 22.04, log4cxx requires C++17 (which is the default).
Enforcing C++14 downgrades the standard, rendering log4cxx uncompilable.