### PR TITLE
fix(franka_gazebo): fix 'set_franka_model_configuration' srv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Requires `libfranka` >= 0.8.0
   * `franka_description`: `<xacro:franka_robot/>` macro now supports to customize the `parent` frame and its `xyz` + `rpy` offset
   * `franka_hw`: Fix the bug where the previous controller is still running after switching the controller. ([#326](https://github.com/frankaemika/franka_ros/issues/326))
   * `franka_gazebo`: Add `set_franka_model_configuration` service.
+  * `franka_gazebo`: Restored the `set_franka_model_configuration` code that was inadvertently removed during a rebase operation.
 
 ## 0.10.1 - 2022-09-15
 

--- a/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
+++ b/franka_gazebo/include/franka_gazebo/franka_hw_sim.h
@@ -158,10 +158,10 @@ class FrankaHWSim : public gazebo_ros_control::RobotHWSim {
   ros::ServiceServer service_set_load_;
   ros::ServiceServer service_collision_behavior_;
   ros::ServiceServer service_user_stop_;
+  ros::ServiceClient service_gazebo_set_model_configuration_;
   ros::ServiceServer service_set_model_configuration_;
   ros::ServiceClient service_controller_list_;
   ros::ServiceClient service_controller_switch_;
-  ros::ServiceClient service_gazebo_set_model_configuration_;
   std::unique_ptr<actionlib::SimpleActionServer<franka_msgs::ErrorRecoveryAction>> action_recovery_;
 
   std::vector<double> lower_force_thresholds_nominal_;


### PR DESCRIPTION
This pull request fixes a problem that was introduced when https://github.com/rickstaa/franka_ros/tree/fix_gazebo_set_model_config_problem was rebased onto the `develop` branch in #226. The force push resulting from this rebase unfortunatelly removed the code that setsup the service.
