### PR TITLE
fix(franka_hw): include cstdint in franka_hw/resource_helpers

### DIFF
--- a/franka_hw/include/franka_hw/resource_helpers.h
+++ b/franka_hw/include/franka_hw/resource_helpers.h
@@ -10,6 +10,7 @@
 #include <hardware_interface/controller_info.h>
 
 #include <franka_hw/control_mode.h>
+#include <cstdint>
 
 namespace franka_hw {
 

--- a/franka_hw/src/resource_helpers.cpp
+++ b/franka_hw/src/resource_helpers.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2023 Franka Robotics GmbH
 // Use of this source code is governed by the Apache-2.0 license, see LICENSE
+#include <cstdint>
 #include <franka_hw/resource_helpers.h>
 
 #include <ros/console.h>

--- a/franka_hw/src/resource_helpers.cpp
+++ b/franka_hw/src/resource_helpers.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2023 Franka Robotics GmbH
 // Use of this source code is governed by the Apache-2.0 license, see LICENSE
-#include <cstdint>
 #include <franka_hw/resource_helpers.h>
 
 #include <ros/console.h>


### PR DESCRIPTION
`franka_hw` wouldn't build for me because it couldn't find type `uint8_t`, this fixes it.

cc: https://github.com/lopsided98/nix-ros-overlay/issues/382