### PR TITLE
Remove reference to non-existing plugin file

### DIFF
--- a/franka_hw/package.xml
+++ b/franka_hw/package.xml
@@ -31,8 +31,4 @@
   <test_depend>franka_description</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>rostest</test_depend>
-
-  <export>
-      <hardware_interface plugin="${prefix}/franka_combinable_hw_plugin.xml"/>
-  </export>
 </package>


### PR DESCRIPTION
`franka_combinable_hw_plugin.xml` doesn't exist. The reference in package.xml triggers the error:
`Skipped loading plugin with error: XML Document '/opt/ros/one/share/franka_hw/franka_combinable_hw_plugin.xml' has no Root Element. This likely means the XML is malformed or missing..`