### PR TITLE
Enable to compile with libfranka 0.14.1

### DIFF
--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -20,9 +20,12 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -26,9 +26,12 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + INCLUDE_DIRS in topological order

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -14,9 +14,12 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -18,9 +18,12 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -9,9 +9,12 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order


### PR DESCRIPTION
This PR enables us to compile this repository with libfranka 0.14.1.

We faced an issue similar to https://github.com/frankaemika/franka_ros/issues/240, and we need libfranka 0.14 according to https://frankaemika.github.io/docs/compatibility.html.
However, current franka_ros assumes that libfranka is 0.9.0 or 0.8.0.
This PR makes franka_ros accept libfranka 0.14.1.

We confirmed that this branch can be compiled with [libfranka 0.14 for ROS melodic](https://github.com/frankaemika/libfranka-release/pull/4) or [libfranka 0.14 for ROS noetic](https://github.com/frankaemika/libfranka-release/pull/5).
We also confirmed that we can control the real robot from ROS melodic.
We did not check, but this branch should also work with libfranka installed by [the official procedure](https://github.com/frankaemika/libfranka/tree/155ddac80565975b58f53eb2feeb85b07a6b9e13?tab=readme-ov-file#getting-started).