### PR TITLE
Enable to compile with libfranka 0.14.1 and 0.15.0

### DIFF
--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -20,9 +20,12 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order

--- a/franka_control/CMakeLists.txt
+++ b/franka_control/CMakeLists.txt
@@ -20,11 +20,14 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
 )
 
-find_package(Franka 0.14.1 QUIET)
+find_package(Franka 0.15.0 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.9.0 QUIET)
+  find_package(Franka 0.14.1 QUIET)
   if(NOT Franka_FOUND)
-    find_package(Franka 0.8.0 REQUIRED)
+    find_package(Franka 0.9.0 QUIET)
+    if(NOT Franka_FOUND)
+      find_package(Franka 0.8.0 REQUIRED)
+    endif()
   endif()
 endif()
 

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -26,9 +26,12 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + INCLUDE_DIRS in topological order

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -26,11 +26,14 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(Franka 0.14.1 QUIET)
+find_package(Franka 0.15.0 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.9.0 QUIET)
+  find_package(Franka 0.14.1 QUIET)
   if(NOT Franka_FOUND)
-    find_package(Franka 0.8.0 REQUIRED)
+    find_package(Franka 0.9.0 QUIET)
+    if(NOT Franka_FOUND)
+      find_package(Franka 0.8.0 REQUIRED)
+    endif()
   endif()
 endif()
 

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -14,11 +14,14 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs
 )
 
-find_package(Franka 0.14.1 QUIET)
+find_package(Franka 0.15.0 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.9.0 QUIET)
+  find_package(Franka 0.14.1 QUIET)
   if(NOT Franka_FOUND)
-    find_package(Franka 0.8.0 REQUIRED)
+    find_package(Franka 0.9.0 QUIET)
+    if(NOT Franka_FOUND)
+      find_package(Franka 0.8.0 REQUIRED)
+    endif()
   endif()
 endif()
 

--- a/franka_gripper/CMakeLists.txt
+++ b/franka_gripper/CMakeLists.txt
@@ -14,9 +14,12 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -18,9 +18,12 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order

--- a/franka_hw/CMakeLists.txt
+++ b/franka_hw/CMakeLists.txt
@@ -18,11 +18,14 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-find_package(Franka 0.14.1 QUIET)
+find_package(Franka 0.15.0 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.9.0 QUIET)
+  find_package(Franka 0.14.1 QUIET)
   if(NOT Franka_FOUND)
-    find_package(Franka 0.8.0 REQUIRED)
+    find_package(Franka 0.9.0 QUIET)
+    if(NOT Franka_FOUND)
+      find_package(Franka 0.8.0 REQUIRED)
+    endif()
   endif()
 endif()
 

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -9,11 +9,14 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-find_package(Franka 0.14.1 QUIET)
+find_package(Franka 0.15.0 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.9.0 QUIET)
+  find_package(Franka 0.14.1 QUIET)
   if(NOT Franka_FOUND)
-    find_package(Franka 0.8.0 REQUIRED)
+    find_package(Franka 0.9.0 QUIET)
+    if(NOT Franka_FOUND)
+      find_package(Franka 0.8.0 REQUIRED)
+    endif()
   endif()
 endif()
 

--- a/franka_visualization/CMakeLists.txt
+++ b/franka_visualization/CMakeLists.txt
@@ -9,9 +9,12 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-find_package(Franka 0.9.0 QUIET)
+find_package(Franka 0.14.1 QUIET)
 if(NOT Franka_FOUND)
-  find_package(Franka 0.8.0 REQUIRED)
+  find_package(Franka 0.9.0 QUIET)
+  if(NOT Franka_FOUND)
+    find_package(Franka 0.8.0 REQUIRED)
+  endif()
 endif()
 
 # merge Franka + catkin INCLUDE_DIRS in topological order


### PR DESCRIPTION
Updated version of #403, which can also be compiled with [libfranka 0.15.0 for ROS melodic](https://github.com/frankarobotics/libfranka-release/pull/6).
We confirmed that we can control the real robot from ROS melodic.